### PR TITLE
Mark ScalableLux as incompatible

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -38,6 +38,7 @@
     "fabric-convention-tags-v2": ">=${fabric_version}"
   },
   "breaks": {
+    "scalablelux": "*",
     "sablecompanion": "<${sable_companion_version}"
   }
 }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -33,6 +33,10 @@ versionRange = "[1.0.6,)"
 ordering = "AFTER"
 side = "CLIENT"
 
+[[dependencies.sable]]
+modId = "scalablelux"
+type = "incompatible"
+
 ["lithium:options"]
 "mixin.entity.collisions.unpushable_cramming" = false
 "mixin.world.chunk_access" = false


### PR DESCRIPTION
ScalableLux is a very popular mod that many people have in their modpacks. It is also fundamentally incompatible with Sable, so marking it as clearly incompatible just makes sense.