### PR TITLE
Fix the command output issue for /sable physics rotation

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/command/SablePhysicsCommands.java
+++ b/common/src/main/java/dev/ryanhcode/sable/command/SablePhysicsCommands.java
@@ -223,11 +223,17 @@ public class SablePhysicsCommands {
         }
 
         if(axis) {
-            SableCommandHelper.sendSuccessDescribingSubLevelsAtIndex("commands.sable.physics.rotation.add.success", ctx, subLevels, 1,
+            SableCommandHelper.sendSuccessDescribingSubLevelsAtIndex(
+                    add ? "commands.sable.physics.rotation.add.success"
+                            : "commands.sable.physics.rotation.set.success",
+                    ctx, subLevels, 1,
                     getGlobalComponent(global), rotationAxis.x + ", " + rotationAxis.y + ", "+ rotationAxis.z + ", " + rotationAngle);
         }else
         {
-            SableCommandHelper.sendSuccessDescribingSubLevelsAtIndex("commands.sable.physics.rotation.add.success", ctx, subLevels, 1,
+            SableCommandHelper.sendSuccessDescribingSubLevelsAtIndex(
+                    add ? "commands.sable.physics.rotation.add.success"
+                            : "commands.sable.physics.rotation.set.success",
+                    ctx, subLevels, 1,
                     getGlobalComponent(global), rotation2.x + ", " + rotation2.y);
         }
         return 0;

--- a/common/src/main/java/dev/ryanhcode/sable/command/SablePhysicsCommands.java
+++ b/common/src/main/java/dev/ryanhcode/sable/command/SablePhysicsCommands.java
@@ -83,9 +83,9 @@ public class SablePhysicsCommands {
                                                 .then(Commands.literal("global")
                                                         .executes((ctx) ->
                                                                 SablePhysicsCommands.executeAddTranslationCommand(ctx, true)))
-                                                        .then(Commands.literal("local")
-                                                                .executes((ctx) ->
-                                                                        SablePhysicsCommands.executeAddTranslationCommand(ctx, false)))
+                                                .then(Commands.literal("local")
+                                                        .executes((ctx) ->
+                                                                SablePhysicsCommands.executeAddTranslationCommand(ctx, false)))
                                         ))
 
                                 .then(Commands.literal("set")
@@ -154,50 +154,47 @@ public class SablePhysicsCommands {
         return 0;
     }
 
-    private static ArgumentBuilder<CommandSourceStack, ?> wrapRotationWithMode(final boolean add)
-    {
-        return Commands.literal(add?"add":"set").then(wrapRotationWithReferenceFrame(add,false)).then(wrapRotationWithReferenceFrame(add,true));
+    private static ArgumentBuilder<CommandSourceStack, ?> wrapRotationWithMode(final boolean add) {
+        return Commands.literal(add ? "add" : "set").then(wrapRotationWithReferenceFrame(add, false)).then(wrapRotationWithReferenceFrame(add, true));
     }
-    private static ArgumentBuilder<CommandSourceStack, ?> wrapRotationWithReferenceFrame(final boolean add, final boolean axis)
-    {
-        final Command<CommandSourceStack> c = (ctx) -> SablePhysicsCommands.executeRotationCommand(ctx,add,axis, true);
-        final Function<ArgumentBuilder<CommandSourceStack, ?>,ArgumentBuilder<CommandSourceStack, ?>> f = (b) -> {
-            if(add)
-                b.then(wrapRotationWithGlobality(axis,true)).then(wrapRotationWithGlobality(axis,false));
+
+    private static ArgumentBuilder<CommandSourceStack, ?> wrapRotationWithReferenceFrame(final boolean add, final boolean axis) {
+        final Command<CommandSourceStack> c = (ctx) -> SablePhysicsCommands.executeRotationCommand(ctx, add, axis, true);
+        final Function<ArgumentBuilder<CommandSourceStack, ?>, ArgumentBuilder<CommandSourceStack, ?>> f = (b) -> {
+            if (add)
+                b.then(wrapRotationWithGlobality(axis, true)).then(wrapRotationWithGlobality(axis, false));
             return b;
         };
-        final ArgumentBuilder<CommandSourceStack, ?> b = axis?
-                Commands.argument("axis", Vec3ArgumentAbsolute.vec3()).then(f.apply(Commands.argument("angle", DoubleArgumentType.doubleArg()).executes(c))):
+        final ArgumentBuilder<CommandSourceStack, ?> b = axis ?
+                Commands.argument("axis", Vec3ArgumentAbsolute.vec3()).then(f.apply(Commands.argument("angle", DoubleArgumentType.doubleArg()).executes(c))) :
                 f.apply(Commands.argument("rotation", RotationArgument.rotation()).executes(c));
 
-        return Commands.literal(axis?"axis":"entity").then(b);
-    }
-    private static ArgumentBuilder<CommandSourceStack, ?> wrapRotationWithGlobality(final boolean axis, final boolean global)
-    {
-        return Commands.literal(global?"global":"local").executes((ctx) ->
-                SablePhysicsCommands.executeRotationCommand(ctx,true,axis, global));
+        return Commands.literal(axis ? "axis" : "entity").then(b);
     }
 
-    private static int executeRotationCommand(final CommandContext<CommandSourceStack> ctx,final boolean add,final boolean axis, final boolean global) throws CommandSyntaxException {
+    private static ArgumentBuilder<CommandSourceStack, ?> wrapRotationWithGlobality(final boolean axis, final boolean global) {
+        return Commands.literal(global ? "global" : "local").executes((ctx) ->
+                SablePhysicsCommands.executeRotationCommand(ctx, true, axis, global));
+    }
 
-
+    private static int executeRotationCommand(final CommandContext<CommandSourceStack> ctx, final boolean add, final boolean axis, final boolean global) throws CommandSyntaxException {
         final PhysicsPipeline pipeline = SableCommandHelper.requireSubLevelPhysicsPipeline(ctx);
 
         final Quaterniond orientation = new Quaterniond();
 
-        Vec2 rotation2=new Vec2(0,0);
-        Vec3 rotationAxis=new Vec3(0,0,0);
-        double rotationAngle=0;
+        Vec2 rotation2 = new Vec2(0, 0);
+        Vec3 rotationAxis = new Vec3(0, 0, 0);
+        double rotationAngle = 0;
 
-        if(axis) {
+        if (axis) {
             rotationAxis = ctx.getArgument("axis", Vec3.class);
-            rotationAngle = ctx.getArgument("angle",Double.class);
-            orientation.fromAxisAngleDeg(rotationAxis.x,rotationAxis.y,rotationAxis.z,rotationAngle);
+            rotationAngle = ctx.getArgument("angle", Double.class);
+            orientation.fromAxisAngleDeg(rotationAxis.x, rotationAxis.y, rotationAxis.z, rotationAngle);
 
-            if(rotationAxis.lengthSqr()==0)
+            if (rotationAxis.lengthSqr() == 0) {
                 throw SableCommandHelper.ERROR_NO_AXIS_FOR_ROTATION.create();
-        }else
-        {
+            }
+        } else {
             rotation2 = RotationArgument.getRotation(ctx, "rotation").getRotation(ctx.getSource());
             orientation.rotateY(-Math.toRadians(rotation2.y));
             orientation.rotateX(Math.toRadians(rotation2.x));
@@ -211,25 +208,25 @@ public class SablePhysicsCommands {
 
         for (final ServerSubLevel subLevel : subLevels) {
             final Pose3d pose = subLevel.logicalPose();
-            if(add) {
+            if (add) {
                 if (global) {
                     pose.orientation().premul(orientation);
                 } else {
                     pose.orientation().mul(orientation);
                 }
-            }else
+            } else {
                 pose.orientation().set(orientation);
+            }
             pipeline.teleport(subLevel, pose.position(), pose.orientation());
         }
 
-        if(axis) {
+        if (axis) {
             SableCommandHelper.sendSuccessDescribingSubLevelsAtIndex(
                     add ? "commands.sable.physics.rotation.add.success"
                             : "commands.sable.physics.rotation.set.success",
                     ctx, subLevels, 1,
-                    getGlobalComponent(global), rotationAxis.x + ", " + rotationAxis.y + ", "+ rotationAxis.z + ", " + rotationAngle);
-        }else
-        {
+                    getGlobalComponent(global), rotationAxis.x + ", " + rotationAxis.y + ", " + rotationAxis.z + ", " + rotationAngle);
+        } else {
             SableCommandHelper.sendSuccessDescribingSubLevelsAtIndex(
                     add ? "commands.sable.physics.rotation.add.success"
                             : "commands.sable.physics.rotation.set.success",


### PR DESCRIPTION
Prior to the fix, both 'set' and 'add' commands produced the output 'added'.
<img width="1583" height="220" src="https://github.com/user-attachments/assets/b7c437c2-c014-484f-9097-d0f08d17c6ea" />
<img width="1487" height="268" src="https://github.com/user-attachments/assets/98aa0eb6-8f92-445d-88c3-3c28f57dec4a" />
<img width="2033" height="281"  src="https://github.com/user-attachments/assets/9205abc8-83f9-4920-baff-f82352993b73" />

After the fix, it is functioning normally.

<img width="1407" height="244" src="https://github.com/user-attachments/assets/a61c887a-e357-4b4f-883c-4b9c23bb3a9c" />
<img width="1407" height="244" src="https://github.com/user-attachments/assets/e804e81e-77b4-4a3d-98d5-ced9f81194ba" />
<img width="1798" height="469" src="https://github.com/user-attachments/assets/bfb4bd80-abfb-424a-b4a0-172d77b2072e" />