### PR TITLE
Support loading Rapier native library via -Dsable_rapier_path=path

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
@@ -56,6 +56,8 @@ public class Rapier3D {
     }
 
     private static void loadLibrary() {
+        if (loadFromProperty()) return;
+
         final String nativeName = getNativeName();
         try (final InputStream is = Rapier3D.class.getResourceAsStream("/natives/" + LIB_NAME + "/" + nativeName)) {
             if (is == null) {
@@ -71,6 +73,19 @@ public class Rapier3D {
 
             Sable.LOGGER.error("Sable has failed to load the natives needed for its Rapier pipeline. Native library name {}. Please report with system details and logs to {}", nativeName, Sable.ISSUE_TRACKER_URL, t);
         }
+    }
+
+    private static boolean loadFromProperty() {
+        final String libPath = System.getProperty("sable_rapier_path");
+        if (libPath != null) {
+            try {
+                System.load(Path.of(libPath).toAbsolutePath().toString());
+                return true;
+            } catch (final Throwable t) {
+                Sable.LOGGER.warn("Sable has failed to load the Rapier pipeline from path {}.", libPath);
+            }
+        }
+        return false;
     }
 
     /**

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
@@ -56,7 +56,10 @@ public class Rapier3D {
     }
 
     private static void loadLibrary() {
-        if (loadFromProperty()) return;
+        if (loadFromProperty()) {
+            ENABLED = true;
+            return;
+        }
 
         final String nativeName = getNativeName();
         try (final InputStream is = Rapier3D.class.getResourceAsStream("/natives/" + LIB_NAME + "/" + nativeName)) {


### PR DESCRIPTION
Support loading Rapier native library via `-Dsable_rapier_path=path`

For users on unsupported systems, this leverages Rust's cross-platform compilation capabilities, allowing them to build and load a custom native library for their specific environment.