### PR TITLE
Move custom shader inputs out of Flywheel’s lighting shader files

### DIFF
--- a/neoforge/src/main/resources/assets/flywheel/flywheel/internal/api_impl.frag
+++ b/neoforge/src/main/resources/assets/flywheel/flywheel/internal/api_impl.frag
@@ -1,0 +1,31 @@
+#include "flywheel:internal/material.glsl"
+#include "flywheel:internal/api_impl.glsl"
+#include "flywheel:internal/uniforms/uniforms.glsl"
+
+in vec4 flw_vertexPos;
+in vec4 flw_vertexColor;
+in vec2 flw_vertexTexCoord;
+flat in ivec2 flw_vertexOverlay;
+in vec2 flw_vertexLight;
+in vec3 flw_vertexNormal;
+
+in float flw_distance;
+
+#ifdef FLW_EMBEDDED
+flat in float flw_skyLightScale;
+flat in uint flw_vertexLightingSceneId;
+in vec4 flw_vertexLightingPos;
+#endif
+
+vec4 flw_sampleColor;
+
+FlwMaterial flw_material;
+
+bool flw_fragDiffuse;
+vec4 flw_fragColor;
+ivec2 flw_fragOverlay;
+vec2 flw_fragLight;
+
+uniform sampler2D flw_diffuseTex;
+uniform sampler2D flw_overlayTex;
+uniform sampler2D flw_lightTex;

--- a/neoforge/src/main/resources/assets/flywheel/flywheel/light/flat.glsl
+++ b/neoforge/src/main/resources/assets/flywheel/flywheel/light/flat.glsl
@@ -1,9 +1,3 @@
-#ifdef FLW_EMBEDDED
-flat in float flw_skyLightScale;
-flat in uint flw_vertexLightingSceneId;
-in vec4 flw_vertexLightingPos;
-#endif
-
 void flw_shaderLight() {
     vec2 embeddedLight;
 

--- a/neoforge/src/main/resources/assets/flywheel/flywheel/light/smooth.glsl
+++ b/neoforge/src/main/resources/assets/flywheel/flywheel/light/smooth.glsl
@@ -1,9 +1,3 @@
-#ifdef FLW_EMBEDDED
-flat in float flw_skyLightScale;
-flat in uint flw_vertexLightingSceneId;
-in vec4 flw_vertexLightingPos;
-#endif
-
 void flw_shaderLight() {
     uint sceneId = 0;
     vec4 vertexLightingPos;

--- a/neoforge/src/main/resources/assets/flywheel/flywheel/light/smooth_when_embedded.glsl
+++ b/neoforge/src/main/resources/assets/flywheel/flywheel/light/smooth_when_embedded.glsl
@@ -1,9 +1,3 @@
-#ifdef FLW_EMBEDDED
-flat in float flw_skyLightScale;
-flat in uint flw_vertexLightingSceneId;
-in vec4 flw_vertexLightingPos;
-#endif
-
 void flw_shaderLight() {
     #ifdef FLW_EMBEDDED
     ivec3 renderOrigin = flw_renderOrigin;


### PR DESCRIPTION
Colorwheel is a mod I develop that implements a custom Flywheel backend compatible with Iris Shaders.

To support shaderpacks with a geometry stage, Colorwheel has to group shader inputs and outputs into a struct:
https://github.com/djefrey/Colorwheel/blob/9fffa2206cf6c814629bc3d7ea77da4e6d401d3b/common/src/main/resources/assets/colorwheel/flywheel/internal/api_impl_geom.glsl

In Flywheel, shader inputs and outputs are currently declared in the `api_impl.frag` and `api_impl.vert` files.
https://github.com/Engine-Room/Flywheel/blob/02af394a2ea4e880dc6b14e409f2e96dc0fa7de8/common/src/backend/resources/assets/flywheel/flywheel/internal/api_impl.frag
https://github.com/Engine-Room/Flywheel/blob/02af394a2ea4e880dc6b14e409f2e96dc0fa7de8/common/src/backend/resources/assets/flywheel/flywheel/internal/api_impl.vert

Sable declares new shader input/outputs: `flw_skyLightScale`,  `flw_vertexLightingSceneId` and `flw_vertexLightingPos`. 
However,  these inputs are declared directly into the lighting shaders that Colorwheel must include.

Because of this, moving these inputs into the struct would require Colorwheel to redefine the lighting shaders redefined by Sable, which I would prefer to avoid.

Instead, these input declarations could be moved to `api_impl.frag` alongside the existing Flywheel inputs. Colorwheel already do not include that file, and would therefore be free to declare them into the struct.