### PR TITLE
Don't do sync sub-level section rebuilds

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/render/vanilla/VanillaChunkedSubLevelRenderData.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/render/vanilla/VanillaChunkedSubLevelRenderData.java
@@ -6,7 +6,6 @@ import com.mojang.blaze3d.vertex.VertexBuffer;
 import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.companion.math.BoundingBox3i;
 import dev.ryanhcode.sable.companion.math.BoundingBox3ic;
-import dev.ryanhcode.sable.companion.math.JOMLConversion;
 import dev.ryanhcode.sable.companion.math.Pose3dc;
 import dev.ryanhcode.sable.mixin.sublevel_render.RenderSectionAccessor;
 import dev.ryanhcode.sable.mixinterface.sublevel_render.vanilla.RenderSectionExtension;
@@ -204,29 +203,12 @@ public class VanillaChunkedSubLevelRenderData implements SubLevelRenderData {
         }
 
         final ProfilerFiller profiler = Minecraft.getInstance().getProfiler();
-        final Vector3d cameraPos = JOMLConversion.atCenterOf(camera.getBlockPosition()).sub(8, 8, 8);
-        this.subLevel.logicalPose().transformPositionInverse(cameraPos);
-
         for (final SectionRenderDispatcher.RenderSection renderSection : this.dirtyRenderSections) {
             ((RenderSectionExtension) renderSection).sable$setListening(false);
 
-            boolean buildSync = false;
-            if (chunkUpdates == PrioritizeChunkUpdates.NEARBY) {
-                final BlockPos origin = renderSection.getOrigin();
-                buildSync = cameraPos.distanceSquared(origin.getX(), origin.getY(), origin.getZ()) < 768.0 || renderSection.isDirtyFromPlayer();
-            } else if (chunkUpdates == PrioritizeChunkUpdates.PLAYER_AFFECTED) {
-                buildSync = renderSection.isDirtyFromPlayer();
-            }
-
-            if (buildSync) {
-                profiler.push("sublevel_build_near_sync");
-                this.sectionRenderDispatcher.rebuildSectionSync(renderSection, renderRegionCache);
-                profiler.pop();
-            } else {
-                profiler.push("sublevel_schedule_async_compile");
-                renderSection.rebuildSectionAsync(this.sectionRenderDispatcher, renderRegionCache);
-                profiler.pop();
-            }
+            profiler.push("sublevel_schedule_async_compile");
+            renderSection.rebuildSectionAsync(this.sectionRenderDispatcher, renderRegionCache);
+            profiler.pop();
 
             renderSection.setNotDirty();
             ((RenderSectionExtension) renderSection).sable$setListening(true);


### PR DESCRIPTION
Fixes major frametime stutter when blocks update on large sub-levels. It was especially bad with redstone clocks. No visual issues or perf regressions found with Sodium/Vanilla/All Flywheel renderers.

Fixes https://github.com/Creators-of-Aeronautics/Simulated-Project/issues/348 (yes I submitted the issue to the wrong repo)