### PR TITLE
Fix Iris matrices when rendering sublevels

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -93,6 +93,7 @@ repositories {
 dependencies {
     compileOnly "maven.modrinth:lithium:mc1.21.1-0.15.3-neoforge"
     compileOnly "maven.modrinth:sodium:$sodium_version"
+    compileOnly "maven.modrinth:iris:$iris_version"
     compileOnly "maven.modrinth:distanthorizons:$distant_horizons_version"
     compileOnly("cc.tweaked:cc-tweaked-$minecraft_version-forge:$cc_tweaked_version")
     compileOnly("io.github.mortuusars.exposure:exposure-${minecraft_version}-neoforge:${exposure_version}") { transitive = false }

--- a/common/src/main/java/dev/ryanhcode/sable/compatibility/SableIrisCompat.java
+++ b/common/src/main/java/dev/ryanhcode/sable/compatibility/SableIrisCompat.java
@@ -1,0 +1,14 @@
+package dev.ryanhcode.sable.compatibility;
+
+import dev.ryanhcode.sable.mixinterface.compatibility.iris.ExtendedShaderExtension;
+import net.minecraft.client.renderer.ShaderInstance;
+
+public class SableIrisCompat {
+
+    public static void refreshModelMatrices(final ShaderInstance shader) {
+        if (shader instanceof final ExtendedShaderExtension ext) {
+            ext.sable$refreshModelMatrices();
+        }
+    }
+
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/iris/ExtendedShaderMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/iris/ExtendedShaderMixin.java
@@ -40,7 +40,7 @@ public class ExtendedShaderMixin implements ExtendedShaderExtension {
 
     @Override
     @Unique
-    public void sable$refreshModelViewDerivedMatrices() {
+    public void sable$refreshModelMatrices() {
         final var modelView = ((ShaderInstance) (Object) this).MODEL_VIEW_MATRIX;
 
         if (modelView != null) {

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/iris/ExtendedShaderMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/iris/ExtendedShaderMixin.java
@@ -38,8 +38,8 @@ public class ExtendedShaderMixin implements ExtendedShaderExtension {
     @Final
     private float[] tempFloats2;
 
-    @Override
     @Unique
+    @Override
     public void sable$refreshModelMatrices() {
         final var modelView = ((ShaderInstance) (Object) this).MODEL_VIEW_MATRIX;
 

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/iris/ExtendedShaderMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/iris/ExtendedShaderMixin.java
@@ -1,0 +1,58 @@
+package dev.ryanhcode.sable.mixin.compatibility.iris;
+
+import com.mojang.blaze3d.shaders.Uniform;
+import dev.ryanhcode.sable.mixinterface.compatibility.iris.ExtendedShaderExtension;
+import net.irisshaders.iris.pipeline.programs.ExtendedShader;
+import net.minecraft.client.renderer.ShaderInstance;
+import org.joml.Matrix3f;
+import org.joml.Matrix4f;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(ExtendedShader.class)
+public class ExtendedShaderMixin implements ExtendedShaderExtension {
+
+    @Shadow
+    @Final
+    private Uniform modelViewInverse;
+
+    @Shadow
+    @Final
+    private Uniform normalMatrix;
+
+    @Shadow
+    @Final
+    private Matrix4f tempMatrix4f;
+
+    @Shadow
+    @Final
+    private Matrix3f tempMatrix3f;
+
+    @Shadow
+    @Final
+    private float[] tempFloats;
+
+    @Shadow
+    @Final
+    private float[] tempFloats2;
+
+    @Override
+    @Unique
+    public void sable$refreshModelViewDerivedMatrices() {
+        final var modelView = ((ShaderInstance) (Object) this).MODEL_VIEW_MATRIX;
+
+        if (modelView != null) {
+            if (this.modelViewInverse != null) {
+                this.modelViewInverse.set(this.tempMatrix4f.set(modelView.getFloatBuffer()).invert().get(this.tempFloats));
+                this.modelViewInverse.upload();
+            }
+
+            if (this.normalMatrix != null) {
+                this.normalMatrix.set(this.tempMatrix3f.set(this.tempMatrix4f.set(modelView.getFloatBuffer())).invert().transpose().get(this.tempFloats2));
+                this.normalMatrix.upload();
+            }
+        }
+    }
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixinterface/compatibility/iris/ExtendedShaderExtension.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixinterface/compatibility/iris/ExtendedShaderExtension.java
@@ -1,0 +1,5 @@
+package dev.ryanhcode.sable.mixinterface.compatibility.iris;
+
+public interface ExtendedShaderExtension {
+    void sable$refreshModelViewDerivedMatrices();
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixinterface/compatibility/iris/ExtendedShaderExtension.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixinterface/compatibility/iris/ExtendedShaderExtension.java
@@ -1,5 +1,5 @@
 package dev.ryanhcode.sable.mixinterface.compatibility.iris;
 
 public interface ExtendedShaderExtension {
-    void sable$refreshModelViewDerivedMatrices();
+    void sable$refreshModelMatrices();
 }

--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/render/vanilla/VanillaChunkedSubLevelRenderData.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/render/vanilla/VanillaChunkedSubLevelRenderData.java
@@ -9,6 +9,7 @@ import dev.ryanhcode.sable.companion.math.BoundingBox3ic;
 import dev.ryanhcode.sable.companion.math.JOMLConversion;
 import dev.ryanhcode.sable.companion.math.Pose3dc;
 import dev.ryanhcode.sable.mixin.sublevel_render.RenderSectionAccessor;
+import dev.ryanhcode.sable.mixinterface.compatibility.iris.ExtendedShaderExtension;
 import dev.ryanhcode.sable.mixinterface.sublevel_render.vanilla.RenderSectionExtension;
 import dev.ryanhcode.sable.sublevel.ClientSubLevel;
 import dev.ryanhcode.sable.sublevel.render.SubLevelRenderData;
@@ -319,6 +320,10 @@ public class VanillaChunkedSubLevelRenderData implements SubLevelRenderData {
         if (shader.MODEL_VIEW_MATRIX != null) {
             shader.MODEL_VIEW_MATRIX.set(modelView.mul(transform, MODEL_MATRIX));
             shader.MODEL_VIEW_MATRIX.upload();
+
+            if (shader instanceof final ExtendedShaderExtension ext) {
+                ext.sable$refreshModelViewDerivedMatrices();
+            }
         }
 
         // TODO: sorting

--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/render/vanilla/VanillaChunkedSubLevelRenderData.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/render/vanilla/VanillaChunkedSubLevelRenderData.java
@@ -324,7 +324,6 @@ public class VanillaChunkedSubLevelRenderData implements SubLevelRenderData {
             if (IrisCompat.isLoaded()) {
                 SableIrisCompat.refreshModelMatrices(shader);
             }
-
         }
 
         // TODO: sorting

--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/render/vanilla/VanillaChunkedSubLevelRenderData.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/render/vanilla/VanillaChunkedSubLevelRenderData.java
@@ -8,16 +8,16 @@ import dev.ryanhcode.sable.companion.math.BoundingBox3i;
 import dev.ryanhcode.sable.companion.math.BoundingBox3ic;
 import dev.ryanhcode.sable.companion.math.JOMLConversion;
 import dev.ryanhcode.sable.companion.math.Pose3dc;
+import dev.ryanhcode.sable.compatibility.SableIrisCompat;
 import dev.ryanhcode.sable.mixin.sublevel_render.RenderSectionAccessor;
-import dev.ryanhcode.sable.mixinterface.compatibility.iris.ExtendedShaderExtension;
 import dev.ryanhcode.sable.mixinterface.sublevel_render.vanilla.RenderSectionExtension;
 import dev.ryanhcode.sable.sublevel.ClientSubLevel;
 import dev.ryanhcode.sable.sublevel.render.SubLevelRenderData;
 import dev.ryanhcode.sable.sublevel.water_occlusion.WaterOcclusionContainer;
 import dev.ryanhcode.sable.sublevel.water_occlusion.WaterOcclusionRegion;
+import foundry.veil.api.compat.IrisCompat;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectList;
-import it.unimi.dsi.fastutil.objects.ObjectLists;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.PrioritizeChunkUpdates;
@@ -321,9 +321,10 @@ public class VanillaChunkedSubLevelRenderData implements SubLevelRenderData {
             shader.MODEL_VIEW_MATRIX.set(modelView.mul(transform, MODEL_MATRIX));
             shader.MODEL_VIEW_MATRIX.upload();
 
-            if (shader instanceof final ExtendedShaderExtension ext) {
-                ext.sable$refreshModelViewDerivedMatrices();
+            if (IrisCompat.isLoaded()) {
+                SableIrisCompat.refreshModelMatrices(shader);
             }
+
         }
 
         // TODO: sorting

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -16,6 +16,7 @@
     "camera.new_camera_types.MinecraftMixin",
     "clip_overwrite.ClientLevelMixin",
     "clip_overwrite.GameRendererMixin",
+    "compatibility.iris.ExtendedShaderMixin",
     "config.GameRendererAccessor",
     "debug_render.DebugRendererMixin",
     "debug_render.DebugScreenOverlayMixin",


### PR DESCRIPTION
Iris replaces `ShaderInstance` with `ExtendedShader`.
When `ExtendedShader.apply()` is called, `modelViewInverse` and `normalMatrix` are updated using `MODEL_VIEW_MATRIX` value.

However, in `VanillaChunkedSubLevelRenderData.renderChunkedSubLevel()`, `MODEL_VIEW_MATRIX.set()` is called after `apply()` has already been called. This leaves the Iris matrices in an incorrect state.

This can be fixed by delaying the `apply()` call until just before rendering.

Before:
<img width="1920" height="1043" alt="2026-04-21_15 27 15" src="https://github.com/user-attachments/assets/70090a47-1a2c-4a9e-8bae-736c7bef08e7" />

After:
<img width="1920" height="1043" alt="2026-04-21_15 26 13" src="https://github.com/user-attachments/assets/90abe632-e177-4916-ac1c-41ecc3d9199a" />
