### PR TITLE
Fix BlockPlaceContext ignores `replaceClick` property.

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/block_placement/BlockPlaceContextMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/block_placement/BlockPlaceContextMixin.java
@@ -124,7 +124,7 @@ public abstract class BlockPlaceContextMixin extends UseOnContext {
                 Mth.floor(localBase.maxZ()));
 
         for (final BlockPos position : stream) {
-            final boolean replaced = this.getLevel().getBlockState(position).canBeReplaced((BlockPlaceContext) (Object) this);
+            final boolean replaced = replaceClicked || this.getLevel().getBlockState(position).canBeReplaced((BlockPlaceContext) (Object) this);
 
             Vector3d inWorldBoxPosition = new Vector3d(position.getX() + 0.5, position.getY() + 0.5, position.getZ() + 0.5);
             final Quaterniond inWorldBoxOrientation = new Quaterniond();


### PR DESCRIPTION
Original `BlockPlaceContext#canPlace` checks on 2 conditions: 
```
    public boolean canPlace() {
        return this.replaceClicked || this.getLevel().getBlockState(this.getClickedPos()).canBeReplaced(this);
    }
```
1. Can Clicked Block be replace?   `BlockStateBase#canBeReplaced`
2. Does this BlockPlaceContext requires forced replacement?   `BlockPlaceContext.replaceClicked`
When one of them is qualified, replacement happens.

In mixin, `replaceClicked` is @Shadow but somehow is ignored. Which causes all forced replacements being ignored.

Should fix these 2 issues:
https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/issues/414
https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/issues/413