### PR TITLE
Little Tiles Partial Compatability

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/voxel_shape_iteration/VoxelShapeMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/voxel_shape_iteration/VoxelShapeMixin.java
@@ -31,6 +31,12 @@ public abstract class VoxelShapeMixin implements FastVoxelShapeIterable {
     @Override
     public Iterator<BoundingBox3dc> sable$allBoxes() {
         synchronized (this) {
+            
+            if(sable$boxIterator == null) {
+                return null;
+                //This is null when this mixin is relevant to little tiles
+            }
+            
             final long id = Thread.currentThread().threadId();
             FastVoxelShapeIterator iterator = this.sable$boxIterator.get(id);
 

--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/entity_collision/SubLevelEntityCollision.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/entity_collision/SubLevelEntityCollision.java
@@ -275,26 +275,29 @@ public class SubLevelEntityCollision {
                         }
 
                         final Iterator<BoundingBox3dc> iterator = ((FastVoxelShapeIterable) voxelShape).sable$allBoxes();
-                        while (iterator.hasNext()) {
-                            final BoundingBox3dc box = iterator.next();
-                            box.center(center);
-                            cubeOBB.getPosition().set(block.getX() + center.x,
-                                    block.getY() + center.y,
-                                    block.getZ() + center.z);
-                            subLevelPose.transformPosition(cubeOBB.getPosition());
-                            box.size(cubeOBB.getDimensions());
+                        //This is null when this is relevant to little tiles
+                        if(iterator != null) {
+                            while (iterator.hasNext()) {
+                                final BoundingBox3dc box = iterator.next();
+                                box.center(center);
+                                cubeOBB.getPosition().set(block.getX() + center.x,
+                                        block.getY() + center.y,
+                                        block.getZ() + center.z);
+                                subLevelPose.transformPosition(cubeOBB.getPosition());
+                                box.size(cubeOBB.getDimensions());
 
-                            OrientedBoundingBox3d.sat(entityBoundsOBB, cubeOBB, mtv);
+                                OrientedBoundingBox3d.sat(entityBoundsOBB, cubeOBB, mtv);
 
-                            if (mtv.lengthSquared() > 0.0 && mtv.x != Double.MAX_VALUE && mtv.y != Double.MAX_VALUE && mtv.z != Double.MAX_VALUE) {
-                                final double lengthMtv = mtv.lengthSquared();
-                                if (lengthMtv > maxMTVLength) {
-                                    maxMTVLength = lengthMtv;
-                                    maxMTV.set(mtv);
+                                if (mtv.lengthSquared() > 0.0 && mtv.x != Double.MAX_VALUE && mtv.y != Double.MAX_VALUE && mtv.z != Double.MAX_VALUE) {
+                                    final double lengthMtv = mtv.lengthSquared();
+                                    if (lengthMtv > maxMTVLength) {
+                                        maxMTVLength = lengthMtv;
+                                        maxMTV.set(mtv);
 
-                                    box.move(block.getX(), block.getY(), block.getZ(), maxAABB);
-                                    maxBlockPos.set(block);
-                                    maxBlockState = state;
+                                        box.move(block.getX(), block.getY(), block.getZ(), maxAABB);
+                                        maxBlockPos.set(block);
+                                        maxBlockState = state;
+                                    }
                                 }
                             }
                         }
@@ -325,35 +328,38 @@ public class SubLevelEntityCollision {
 
                         boolean discard = false;
                         final Iterator<BoundingBox3dc> iterator = ((FastVoxelShapeIterable) offsetShape).sable$allBoxes();
-                        while (iterator.hasNext()) {
-                            final BoundingBox3dc box = iterator.next();
-                            box.move(newPos.getX(), newPos.getY(), newPos.getZ(), offsetAABB).expand(0.001);
-                            if (!maxAABB.intersects(offsetAABB)) {
-                                continue;
-                            }
+                        //This is null when this is relevant to little tiles
+                        if(iterator != null) {
+                            while (iterator.hasNext()) {
+                                final BoundingBox3dc box = iterator.next();
+                                box.move(newPos.getX(), newPos.getY(), newPos.getZ(), offsetAABB).expand(0.001);
+                                if (!maxAABB.intersects(offsetAABB)) {
+                                    continue;
+                                }
 
-                            compressedMinAABB.set(
-                                    maxAABB.minX * (1.0 - direction.getStepX()),
-                                    maxAABB.minY * (1.0 - direction.getStepY()),
-                                    maxAABB.minZ * (1.0 - direction.getStepZ()),
-                                    maxAABB.maxX * (1.0 - direction.getStepX()) + direction.getStepX(),
-                                    maxAABB.maxY * (1.0 - direction.getStepY()) + direction.getStepY(),
-                                    maxAABB.maxZ * (1.0 - direction.getStepZ()) + direction.getStepZ()
-                            );
+                                compressedMinAABB.set(
+                                        maxAABB.minX * (1.0 - direction.getStepX()),
+                                        maxAABB.minY * (1.0 - direction.getStepY()),
+                                        maxAABB.minZ * (1.0 - direction.getStepZ()),
+                                        maxAABB.maxX * (1.0 - direction.getStepX()) + direction.getStepX(),
+                                        maxAABB.maxY * (1.0 - direction.getStepY()) + direction.getStepY(),
+                                        maxAABB.maxZ * (1.0 - direction.getStepZ()) + direction.getStepZ()
+                                );
 
-                            compressedOffsetAABB.set(
-                                    offsetAABB.minX * (1.0 - direction.getStepX()),
-                                    offsetAABB.minY * (1.0 - direction.getStepY()),
-                                    offsetAABB.minZ * (1.0 - direction.getStepZ()),
-                                    offsetAABB.maxX * (1.0 - direction.getStepX()) + direction.getStepX(),
-                                    offsetAABB.maxY * (1.0 - direction.getStepY()) + direction.getStepY(),
-                                    offsetAABB.maxZ * (1.0 - direction.getStepZ()) + direction.getStepZ()
-                            );
+                                compressedOffsetAABB.set(
+                                        offsetAABB.minX * (1.0 - direction.getStepX()),
+                                        offsetAABB.minY * (1.0 - direction.getStepY()),
+                                        offsetAABB.minZ * (1.0 - direction.getStepZ()),
+                                        offsetAABB.maxX * (1.0 - direction.getStepX()) + direction.getStepX(),
+                                        offsetAABB.maxY * (1.0 - direction.getStepY()) + direction.getStepY(),
+                                        offsetAABB.maxZ * (1.0 - direction.getStepZ()) + direction.getStepZ()
+                                );
 
-                            compressedMinAABB.intersect(compressedOffsetAABB, intersection);
-                            if (Math.abs(intersection.volume() - compressedMinAABB.volume()) < 0.01) {
-                                discard = true;
-                                break;
+                                compressedMinAABB.intersect(compressedOffsetAABB, intersection);
+                                if (Math.abs(intersection.volume() - compressedMinAABB.volume()) < 0.01) {
+                                    discard = true;
+                                    break;
+                                }
                             }
                         }
 
@@ -570,6 +576,8 @@ public class SubLevelEntityCollision {
             }
 
             final Iterator<BoundingBox3dc> iterator = ((FastVoxelShapeIterable) voxelShape).sable$allBoxes();
+            //This is null when this is relevant to little tiles
+            if(iterator == null) return false;
             final Vector3d center = sink.center;
             final Vector3d mtv = sink.mtv;
 

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -61,7 +61,3 @@ reason = "Sable is out of date"
 [[dependencies.sable]]
 modId = "scalablelux"
 type = "incompatible"
-
-[[dependencies.sable]]
-modId = "littletiles"
-type = "incompatible"


### PR DESCRIPTION
**The Issue I'm Trying to Fix**
Little Tiles incompatability. It [crashes](https://pastebin.com/ujvkkUwt) when physics objects have little tiles on them and an entity collides with the physics object. Notably no crash occurs when physics objects collide with little tiles in the "real world", they just simply treat the little tiles as if they dont exist.

**What I Did**
When [VoxelShapeMixin.sable$allBoxes](https://github.com/ryanhcode/sable/blob/main/common/src/main/java/dev/ryanhcode/sable/mixin/voxel_shape_iteration/VoxelShapeMixin.java#L23) is called in a context relevant to little tiles, it will always be null. I added some null checks for this in entity collision, and just skip over the relevant code if it is null. 

**The Results**
This results in little tile blocks being placeable and visible on physics objects, however little tile blocks are completely ignored for physics object collision checks. (same as when a physics object collides with little tile blocks in the "real world")

I have not tested little tiles advanced functionality as I dont have experience working with that stuff in the first place, I just make visual stuff.

Little Tiles on physics objects do not render upon first entering a world, requiring a little tile to be modified on the physics object to make little tiles on that physics object visible again.

Little Tiles are also not highlightable or breakable by hand while on physics objects. They can still be modified by little tiles tools and premade structures can be placed.

Little Tiles in the "real world" are not affected at all (from my testing) by these changes.

**Other Options**
Option 1: A better (but still easier than full compatability) option would be to prevent Little Tiles from being placed on physics objects in the first place. However, doing so via preventing placement via [canPlace](https://github.com/ryanhcode/sable/blob/main/common/src/main/java/dev/ryanhcode/sable/mixin/block_placement/BlockPlaceContextMixin.java#L79) doesnt work due to LittleTiles placement logic not obeying canPlace. (And I'm not smart enough to figure out how their placement logic works). If there is a way to prevent certain blocks or block types from existing on Sub-Levels on a deeper level that would be better (and honestly a great addition, gonna make a relevant issue for this) 

Option 2: Instead of skipping the relevant code, generate a full-box collision for little tiles. Depending on opinion, this may be better than them having no collision. I'm whatever either way I just dont know how to do this.
