### PR TITLE
Remove duplicate 'minecraft:soul_soil' entry

### DIFF
--- a/common/src/main/resources/data/sable/tags/block/frictive.json
+++ b/common/src/main/resources/data/sable/tags/block/frictive.json
@@ -3,7 +3,6 @@
   "values": [
     "minecraft:soul_sand",
     "minecraft:soul_soil",
-    "minecraft:soul_soil",
     "minecraft:honey_block",
     "minecraft:cactus",
     { "id": "create:belt", "required": false }]


### PR DESCRIPTION
Removed duplicate entry for 'minecraft:soul_soil' in frictive tag

fixes #521 