### PR TITLE
Update Veil to 4.0.0

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-loader.gradle
+++ b/buildSrc/src/main/groovy/multiloader-loader.gradle
@@ -77,6 +77,7 @@ publishMods {
         }
 
         embeds("veil-lib")
+        optional "imguimc"
     }
 
     modrinth {
@@ -94,6 +95,7 @@ publishMods {
         }
 
         embeds("veil")
+        optional "imguimc"
     }
 
     github {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -249,6 +249,7 @@ dependencies {
     implementation("foundry.veil:veil-common-${project.minecraft_version}:${project.veil_version}") {
         exclude group: "maven.modrinth"
     }
+    compileOnly("foundry.imguimc:imguimc-common-${project.minecraft_version}:${project.imguimc_version}")
 
     compileOnly("fuzs.forgeconfigapiport:forgeconfigapiport-fabric:${forgeconfigapiport_version}") {
         transitive = false

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     modCompileOnly "maven.modrinth:sodium-extras:fabric-${minecraft_version}-$sodiumextras_version"
 
     include(modApi("foundry.veil:veil-fabric-${project.minecraft_version}:${project.veil_version}"))
+    modCompileOnly("foundry.imguimc:imguimc-fabric-${project.minecraft_version}:${project.imguimc_version}")
 
     include(modApi("fuzs.forgeconfigapiport:forgeconfigapiport-fabric:${forgeconfigapiport_version}")) //source: https://github.com/Fuzss/forgeconfigapiport-fabric
     include(implementation('org.tukaani:xz:1.10'))

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,8 @@ neoforge_loader_version_range=[4,)
 # Dependencies
 sable_companion_version=1.6.0
 forgeconfigapiport_version=21.1.3
-veil_version=3.6.2
+veil_version=4.0.0
+imguimc_version=1.1.0
 
 ## Create
 create_version=6.0.10-280

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -98,4 +98,5 @@ dependencies {
         exclude group: "maven.modrinth"
         exclude group: "me.fallenbreath"
     })
+    compileOnly("foundry.imguimc:imguimc-neoforge-${project.minecraft_version}:${project.imguimc_version}")
 }


### PR DESCRIPTION
This PR updates Veil to `4.0.0` which does the following:
- Removes ImGui natives
- Fixes incompatibility with Axiom or any other mod that ships ImGui
- Adds an optional dependency on `imguimc`
- Reduces jar size by ~12MB
- Closes #106
- Closes #502