### PR TITLE
feat: add loongarch64 (LoongArch) architecture & riscv64 (RISC-V) arc…

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -19,7 +19,8 @@ def mac(arch) {
 }
 
 def linux(arch) {
-    [triple: "${arch}-unknown-linux-gnu", suffix: ".2.17", arch: arch, os: "linux", ext: "so", lib: true]
+    def glibcVersion = (arch in ["loongarch64", "riscv64gc"]) ? ".2.36" : ".2.17"
+    [triple: "${arch}-unknown-linux-gnu", suffix: glibcVersion, arch: arch, os: "linux", ext: "so", lib: true]
 }
 
 def freebsd(arch) {
@@ -35,6 +36,8 @@ def supportedTargets = [
         mac("aarch64"),
         linux("x86_64"),
         linux("aarch64"),
+        linux("loongarch64"),
+        linux("riscv64gc"),
         windows("x86_64"),
         windows("aarch64"),
 //        freebsd("x86_64"),

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
@@ -42,8 +42,13 @@ public class Rapier3D {
 
     private static String getNativeName() {
         final String arch;
-        if (System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").startsWith("aarch64")) {
+        String osArch = System.getProperty("os.arch");
+        if (osArch.equals("arm") || osArch.startsWith("aarch64")) {
             arch = "aarch64";
+        } else if (osArch.startsWith("loongarch64") || osArch.equals("loong64")) {
+            arch = "loongarch64";
+        } else if (osArch.startsWith("riscv64") || osArch.equals("riscv64gc")) {
+            arch = "riscv64";
         } else {
             arch = "x86_64";
         }

--- a/common/src/main/rust/container/zigbuild/Dockerfile
+++ b/common/src/main/rust/container/zigbuild/Dockerfile
@@ -7,6 +7,8 @@ RUN rustup target add x86_64-apple-darwin
 RUN rustup target add aarch64-apple-darwin
 RUN rustup target add x86_64-unknown-linux-gnu
 RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup target add loongarch64-unknown-linux-gnu
+RUN rustup target add riscv64gc-unknown-linux-gnu
 RUN rustup target add x86_64-unknown-freebsd
 # used for AArch64 FreeBSD
 #RUN rustup component add rust-src


### PR DESCRIPTION
…hitecture support

This is a fresh start. The following changes enable cross-compilation and runtime support for LoongArch64 and RISC-V 64-bit architectures.

Changes:

1. build.gradle
   - Add loongarch64 and riscv64 to supportedTargets
   - Override glibc version: use 2.36 for loongarch64 & riscv64, keep 2.17 for others

2. Rapier3D.java
   - Add architecture detection for loongarch64 (os.arch starts with loongarch64 or loong64)
   - Add architecture detection for riscv64 (os.arch starts with riscv64 or riscv64gc)
   - Map them to native library names: sable_rapier_loongarch64_linux.so, sable_rapier_riscv64_linux.so

3. Dockerfile (container/zigbuild)
   - Add rustup target: loongarch64-unknown-linux-gnu
   - Add rustup target: riscv64gc-unknown-linux-gnu

These modifications allow the project to build and run on Loongson (LoongArch64) and RISC-V 64-bit platforms. glibc 2.36 is explicitly set for these two architectures to satisfy toolchain requirements.