### PR TITLE
Fix physics property crash with some modded blocks

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/collider/PhysicsColliderBlockGetter.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/collider/PhysicsColliderBlockGetter.java
@@ -1,0 +1,56 @@
+package dev.ryanhcode.sable.physics.impl.rapier.collider;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Physics data is specific for each block regardless of where it's placed or what possible block entity state may exist.
+ * This class makes sure any blocks that attempt to change state based on their neighbors will not cause crashes.
+ */
+@ApiStatus.Internal
+public final class PhysicsColliderBlockGetter implements BlockGetter {
+
+    private final BlockGetter level;
+    private BlockState state;
+
+    public PhysicsColliderBlockGetter(final BlockGetter level) {
+        this.level = level;
+    }
+
+    public void setup(final BlockState state) {
+        this.state = state;
+    }
+
+    @Override
+    public @Nullable BlockEntity getBlockEntity(final @NotNull BlockPos pos) {
+        return null;
+    }
+
+    @Override
+    public @NotNull BlockState getBlockState(@NotNull final BlockPos pos) {
+        return BlockPos.ZERO.equals(pos) ? this.state : Blocks.AIR.defaultBlockState();
+    }
+
+    @Override
+    public @NotNull FluidState getFluidState(@NotNull final BlockPos pos) {
+        return BlockPos.ZERO.equals(pos) ? this.state.getFluidState() : Fluids.EMPTY.defaultFluidState();
+    }
+
+    @Override
+    public int getHeight() {
+        return this.level.getHeight();
+    }
+
+    @Override
+    public int getMinBuildHeight() {
+        return this.level.getMinBuildHeight();
+    }
+}

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/collider/RapierVoxelColliderBakery.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/collider/RapierVoxelColliderBakery.java
@@ -34,7 +34,7 @@ public class RapierVoxelColliderBakery {
      * @param blockGetter the level to collide with
      */
     public RapierVoxelColliderBakery(@NotNull final BlockGetter blockGetter) {
-        this.level = blockGetter;
+        this.level = new PhysicsColliderBlockGetter(blockGetter);
     }
 
     /**


### PR DESCRIPTION
Twilight forest uses neighboring blocks to determine what its voxel shape should be. However, this is not allowed when calculating physics properties as it causes a recursive update in some cases. This prevents mods from loading chunks when calculating physics properties by treating the block as a single block in a void world. This will likely produce incorrect results for twilight forest, but they should be trying to set the voxel shape based on neighbors.

Closes #387 and related duplicates