### PR TITLE
Added more compatibility for Iron's Spells and Spellbooks

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_aabb_lookup/LevelMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_aabb_lookup/LevelMixin.java
@@ -1,0 +1,30 @@
+package dev.ryanhcode.sable.mixin.entity.entity_aabb_lookup;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import dev.ryanhcode.sable.Sable;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import org.joml.Vector3d;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+@Mixin(Level.class)
+public class LevelMixin {
+
+	@Unique
+	private Level sable$level = (Level) (Object) this;
+
+	@WrapMethod(method = "getEntities(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;")
+	public List<Entity> getEntities(final Entity entity, final AABB boundingBox, final Predicate<? super Entity> predicate, final Operation<List<Entity>> original) {
+		final Vector3d minCorner = Sable.HELPER.projectOutOfSubLevel(this.sable$level, new Vector3d(boundingBox.minX, boundingBox.minY, boundingBox.minZ));
+		final Vector3d maxCorner = Sable.HELPER.projectOutOfSubLevel(this.sable$level, new Vector3d(boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ));
+		final AABB outOfSubLevelBoundingBox = new AABB(minCorner.x, minCorner.y, minCorner.z, maxCorner.x, maxCorner.y, maxCorner.z);
+		return original.call(entity, outOfSubLevelBoundingBox, predicate);
+	}
+
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/teleport_players/ServerPlayerMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/teleport_players/ServerPlayerMixin.java
@@ -2,21 +2,49 @@ package dev.ryanhcode.sable.mixin.entity.teleport_players;
 
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.mojang.authlib.GameProfile;
 import dev.ryanhcode.sable.Sable;
+import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.entity.RelativeMovement;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
 import java.util.Set;
 
 @Mixin(ServerPlayer.class)
-public class ServerPlayerMixin {
+public abstract class ServerPlayerMixin extends Player {
+
+    public ServerPlayerMixin(final Level level, final BlockPos pos, final float yRot, final GameProfile gameProfile) {
+        super(level, pos, yRot, gameProfile);
+    }
+
+    @Shadow
+    public abstract ServerLevel serverLevel();
+
+    @Shadow
+    public ServerGamePacketListenerImpl connection;
 
     @WrapMethod(method = "teleportTo(Lnet/minecraft/server/level/ServerLevel;DDDLjava/util/Set;FF)Z")
     public boolean sable$teleportTo(final ServerLevel serverLevel, final double x, final double y, final double z, final Set<RelativeMovement> set, final float g, final float h, final Operation<Boolean> original) {
         final Vector3d globalPos = Sable.HELPER.projectOutOfSubLevel(serverLevel, new Vector3d(x, y, z));
         return original.call(serverLevel, globalPos.x, globalPos.y, globalPos.z, set, g, h);
+    }
+    
+    @WrapMethod(method = "teleportTo(DDD)V")
+    public void onTeleport(final double x, final double y, final double z, final Operation<Void> original) {
+        final Vector3d globalPos = Sable.HELPER.projectOutOfSubLevel(this.serverLevel(), new Vector3d(x, y, z));
+        original.call(globalPos.x, globalPos.y, globalPos.z);
+    }
+
+    @WrapMethod(method = "teleportRelative")
+    public void onTeleportRelative(final double dx, final double dy, final double dz, final Operation<Void> original) {
+        final Vector3d globalPos = Sable.HELPER.projectOutOfSubLevel(this.serverLevel(), new Vector3d(this.getX() + dx, this.getY() + dy, this.getZ() + dz));
+        this.connection.teleport(globalPos.x, globalPos.y, globalPos.z, this.getYRot(), this.getXRot(), RelativeMovement.ALL);
     }
 }

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -120,6 +120,7 @@
     "entity.entities_stick_sublevels.player.ServerboundMovePlayerPacketMixin",
     "entity.entities_stick_sublevels.player.ServerGamePacketListenerImplMixin",
     "entity.entities_stick_sublevels.player.ServerPlayerMixin",
+    "entity.entity_aabb_lookup.LevelMixin",
     "entity.entity_aabb_lookup.LevelsMixin",
     "entity.entity_ai.EatBlockGoalMixin",
     "entity.entity_collision.CollisionContextMixin",

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,6 +56,7 @@ iris_version=1.8.12+1.21.1-neoforge
 distant_horizons_version=2.2.1-a-1.21.1
 nml_version=1.4.3
 sodiumextras_version=1.0.8
+irons_spells_n_spellbooks_version=1.21.1-3.15.6
 
 loom.ignoreDependencyLoomVersionValidation=true
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -90,6 +90,8 @@ dependencies {
     compileOnly("maven.modrinth:iris:$iris_version") { transitive = false }
     compileOnly("maven.modrinth:sodium-extras:neoforge-${minecraft_version}-$sodiumextras_version") { transitive = false }
 
+    compileOnly("maven.modrinth:irons-spells-n-spellbooks:$irons_spells_n_spellbooks_version") { transitive = false }
+
     jarJar(api("foundry.veil:veil-neoforge-${project.minecraft_version}:${project.veil_version}") {
         exclude group: "maven.modrinth"
         exclude group: "me.fallenbreath"

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/irons_spellbooks/PortalFrameBlockMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/irons_spellbooks/PortalFrameBlockMixin.java
@@ -1,0 +1,23 @@
+package dev.ryanhcode.sable.neoforge.mixin.compatibility.irons_spellbooks;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import dev.ryanhcode.sable.Sable;
+import io.redspace.ironsspellbooks.block.portal_frame.PortalFrameBlock;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(PortalFrameBlock.class)
+public class PortalFrameBlockMixin {
+
+	@WrapOperation(method = "entityInside", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/shapes/VoxelShape;move(DDD)Lnet/minecraft/world/phys/shapes/VoxelShape;"))
+	public VoxelShape onEntityInside(final VoxelShape instance, final double xOffset, final double yOffset, final double zOffset, final Operation<VoxelShape> original, @Local(argsOnly = true) final Level pLevel, @Local(argsOnly = true) final BlockPos pPos) {
+		final var newPosVec = Sable.HELPER.projectOutOfSubLevel(pLevel, pPos.getBottomCenter());
+		return original.call(instance, newPosVec.x, newPosVec.y, newPosVec.z);
+	}
+
+}

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/irons_spellbooks/TouchDigSpellMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/irons_spellbooks/TouchDigSpellMixin.java
@@ -1,0 +1,22 @@
+package dev.ryanhcode.sable.neoforge.mixin.compatibility.irons_spellbooks;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import dev.ryanhcode.sable.Sable;
+import io.redspace.ironsspellbooks.spells.nature.TouchDigSpell;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(TouchDigSpell.class)
+public class TouchDigSpellMixin {
+
+	@WrapOperation(method = "onCast", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/BlockHitResult;getLocation()Lnet/minecraft/world/phys/Vec3;"))
+	public Vec3 particleVec(final BlockHitResult instance, final Operation<Vec3> original, @Local(argsOnly = true) final Level level) {
+		return Sable.HELPER.projectOutOfSubLevel(level, original.call(instance));
+	}
+
+}

--- a/neoforge/src/main/resources/sable-neoforge.mixins.json
+++ b/neoforge/src/main/resources/sable-neoforge.mixins.json
@@ -161,6 +161,7 @@
     "compatibility.create.vertical_gearbox.VerticalGearboxItemMixin",
     "compatibility.create.zapper.ZapperItemMixin",
     "compatibility.irons_spellbooks.PortalFrameBlockMixin",
+    "compatibility.irons_spellbooks.TouchDigSpellMixin",
     "compatibility.pmweather.AnemometerBlockEntityMixin",
     "compatibility.pmweather.AnemometerBlockMixin",
     "compatibility.pmweather.PMWeatherMixin",

--- a/neoforge/src/main/resources/sable-neoforge.mixins.json
+++ b/neoforge/src/main/resources/sable-neoforge.mixins.json
@@ -160,6 +160,7 @@
     "compatibility.create.turntable.TurntableBlockMixin",
     "compatibility.create.vertical_gearbox.VerticalGearboxItemMixin",
     "compatibility.create.zapper.ZapperItemMixin",
+    "compatibility.irons_spellbooks.PortalFrameBlockMixin",
     "compatibility.pmweather.AnemometerBlockEntityMixin",
     "compatibility.pmweather.AnemometerBlockMixin",
     "compatibility.pmweather.PMWeatherMixin",


### PR DESCRIPTION
Besides the game-breaking crash, there were a few smaller issues when using Iron's spells and/or blocks in sublevels.

In this PR I fixed the following issues; 
- Portal frames detecting players entering when it's placed in a sublevel.
- Particles of the Touch Dig beam don't calculate all the way to the sublevel plot.

Issues which still exist:
- When teleporting from the world to a sublevel using a portal frame, the rotation of the sublevel is not accounted for.

Expands on #700 