### PR TITLE
Add ability to set constraint limits

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/api/physics/constraint/PhysicsConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/physics/constraint/PhysicsConstraintHandle.java
@@ -31,6 +31,15 @@ public interface PhysicsConstraintHandle {
     void setMotor(ConstraintJointAxis axis, double target, double stiffness, double damping, boolean hasMaxForce, double maxForce);
 
     /**
+     * Sets limits on this joint
+     *
+     * @param axis The axis on which the limits are set
+     * @param minPosition The minimum position along that axis [m | rad]
+     * @param maxPosition The maximum position along that axis [m | rad]
+     */
+    void setLimits(ConstraintJointAxis axis, double minPosition, double maxPosition);
+
+    /**
      * Removes the constraint from the active physics engine
      */
     void remove();

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
@@ -495,6 +495,15 @@ public class Rapier3D {
     public static native void setConstraintMotor(final int dimensionID, long handle, int axis, double desiredPosition, double stiffness, double damping, boolean hasForceLimit, double maxForce);
 
     /**
+     * Sets constraint limits along a specified axis.
+     *
+     * @param dimensionID the ID of the dimension
+     * @param handle      the handle of the constraint
+     */
+    @ApiStatus.Internal
+    public static native void setConstraintLimits(final int dimensionID, long handle, int axis, double minPosition, double maxPosition);
+
+    /**
      * Adds linear and angular velocities
      *
      * @param bodyId   the ID of an already created rigid-body

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/RapierConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/RapierConstraintHandle.java
@@ -67,6 +67,18 @@ public abstract class RapierConstraintHandle implements PhysicsConstraintHandle 
     }
 
     /**
+     * Sets limits on this joint
+     *
+     * @param axis The axis on which the limits are set
+     * @param minPosition The minimum position along that axis [m | rad]
+     * @param maxPosition The maximum position along that axis [m | rad]
+     */
+    @Override
+    public void setLimits(ConstraintJointAxis axis, double minPosition, double maxPosition) {
+        Rapier3D.setConstraintLimits(this.sceneID, this.handle, axis.ordinal(), minPosition, maxPosition);
+    }
+
+    /**
      * Removes the constraint from the active physics engine
      */
     @Override

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/RapierConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/RapierConstraintHandle.java
@@ -74,7 +74,7 @@ public abstract class RapierConstraintHandle implements PhysicsConstraintHandle 
      * @param maxPosition The maximum position along that axis [m | rad]
      */
     @Override
-    public void setLimits(ConstraintJointAxis axis, double minPosition, double maxPosition) {
+    public void setLimits(final ConstraintJointAxis axis, final double minPosition, final double maxPosition) {
         Rapier3D.setConstraintLimits(this.sceneID, this.handle, axis.ordinal(), minPosition, maxPosition);
     }
 

--- a/common/src/main/rust/rapier/src/joints.rs
+++ b/common/src/main/rust/rapier/src/joints.rs
@@ -156,6 +156,37 @@ pub extern "system" fn Java_dev_ryanhcode_sable_physics_impl_rapier_Rapier3D_set
 }
 
 #[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_ryanhcode_sable_physics_impl_rapier_Rapier3D_setConstraintLimits<
+    'local,
+>(
+    _env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    scene_id: jint,
+    joint_id: jlong,
+    axis: jint,
+    min: jdouble,
+    max: jdouble,
+) {
+    let scene = get_scene_mut_ref(scene_id);
+    let Some(joint) = scene.joint_set.joints.get(&joint_id) else {
+        return;
+    };
+
+    let data = &mut scene
+        .impulse_joint_set
+        .get_mut(joint.handle, false)
+        .unwrap()
+        .data;
+    data.set_limits(
+        AXES[axis as usize],
+        [
+            min as Real,
+            max as Real,
+        ],
+    );
+}
+
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_ryanhcode_sable_physics_impl_rapier_Rapier3D_isConstraintValid<
     'local,
 >(


### PR DESCRIPTION
Add binding for `rapier3d::dynamics::GenericJoint::set_limits` for setting limit ranges on physics constraints.