### PR TITLE
Add entity fall on block mixin for seats

### DIFF
--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/entity_falls_on_block/SeatBlockMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/entity_falls_on_block/SeatBlockMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
- * Makes seats use the standing on position of entities instead of their block position for picking them up, as the
+ * Makes seats use the standing on position of entities instead of their block position for sitting them down, as the
  * on position of entities will be overwritten by Sable to be inside of the plot of a sub-level an entity is resting on
  */
 @Mixin(SeatBlock.class)

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/entity_falls_on_block/SeatBlockMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/entity_falls_on_block/SeatBlockMixin.java
@@ -1,0 +1,23 @@
+package dev.ryanhcode.sable.neoforge.mixin.compatibility.create.entity_falls_on_block;
+
+import com.simibubi.create.content.contraptions.actors.seat.SeatBlock;
+import com.simibubi.create.content.processing.basin.BasinBlock;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * Makes seats use the standing on position of entities instead of their block position for picking them up, as the
+ * on position of entities will be overwritten by Sable to be inside of the plot of a sub-level an entity is resting on
+ */
+@Mixin(SeatBlock.class)
+public class SeatBlockMixin {
+
+    @Redirect(method = "updateEntityAfterFallOn", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;blockPosition()Lnet/minecraft/core/BlockPos;"))
+    private BlockPos sable$updateEntityAfterFallOn(final Entity instance) {
+        return instance.getOnPos();
+    }
+
+}

--- a/neoforge/src/main/resources/sable-neoforge.mixins.json
+++ b/neoforge/src/main/resources/sable-neoforge.mixins.json
@@ -101,6 +101,7 @@
     "compatibility.create.entity_falls_on_block.BasinBlockMixin",
     "compatibility.create.entity_falls_on_block.BeltMillstoneBlocksMixin",
     "compatibility.create.entity_falls_on_block.SawBlockMixin",
+    "compatibility.create.entity_falls_on_block.SeatBlockMixin",
     "compatibility.create.factory_panel.FactoryPanelConnectionHandlerMixin",
     "compatibility.create.fans_provide_force.EncasedFanBlockEntityMixin",
     "compatibility.create.fluid_handling.OpenEndedPipeMixin",


### PR DESCRIPTION
Fixes #355 and #581. Uses identical pattern to SawBlockMixin to replace the getBlockPos with a sublevel considerate one.
<img width="261" height="296" alt="image" src="https://github.com/user-attachments/assets/c889d18e-6326-40ac-bded-3ef8d3ec01a8" />

