### PR TITLE
Add after assemble hook for structure block integrity check

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/api/SubLevelAssemblyHelper.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/SubLevelAssemblyHelper.java
@@ -410,6 +410,15 @@ public class SubLevelAssemblyHelper {
             final BlockState subLevelState = Blocks.AIR.defaultBlockState();
             resultingLevel.sendBlockUpdated(block, Blocks.STONE.defaultBlockState(), subLevelState, 3);
         }
+
+        for (final BlockPos block : blocks) {
+            final BlockPos newPos = transform.apply(block);
+            final BlockState state = accelerator.getBlockState(newPos);
+
+            if (state.getBlock() instanceof final BlockSubLevelAssemblyListener listener) {
+                listener.afterAssemble(level, resultingLevel, state, block, newPos);
+            }
+        }
     }
 
     public static void markAndNotifyBlock(final Level level, final BlockPos pPos, @Nullable final LevelChunk levelchunk, final BlockState oldState, final BlockState newState, final int pFlags, final int pRecursionLeft) {

--- a/common/src/main/java/dev/ryanhcode/sable/api/block/BlockSubLevelAssemblyListener.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/block/BlockSubLevelAssemblyListener.java
@@ -24,8 +24,6 @@ public interface BlockSubLevelAssemblyListener {
 
     }
 
-
-
     /**
      * Called after the {@link SubLevelAssemblyHelper} has moved a block of state newState from oldPos to newPos.
      * At this point in time during the move, the old block has not been removed.
@@ -37,5 +35,17 @@ public interface BlockSubLevelAssemblyListener {
      * @param newPos the new block position
      */
     void afterMove(ServerLevel originLevel, ServerLevel resultingLevel, BlockState newState, BlockPos oldPos, BlockPos newPos);
+
+    /**
+     * Called after the {@link SubLevelAssemblyHelper} has assembled the complete sublevel from oldPos to newPos.
+     * This means that blocks that were included in assembly have been moved.
+     *
+     * @param originLevel the level the block was moved from
+     * @param resultingLevel the level the block was moved to
+     * @param newState the new block state
+     * @param oldPos the old block position
+     * @param newPos the new block position
+     */
+    default void afterAssemble(ServerLevel originLevel, ServerLevel resultingLevel, BlockState newState, BlockPos oldPos, BlockPos newPos) {}
 
 }

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/water_wheel_structure/WaterWheelStructuralBlockMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/water_wheel_structure/WaterWheelStructuralBlockMixin.java
@@ -1,0 +1,34 @@
+package dev.ryanhcode.sable.neoforge.mixin.compatibility.create.water_wheel_structure;
+
+import com.simibubi.create.content.kinetics.waterwheel.WaterWheelStructuralBlock;
+import dev.ryanhcode.sable.api.block.BlockSubLevelAssemblyListener;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.DirectionalBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(WaterWheelStructuralBlock.class)
+public abstract class WaterWheelStructuralBlockMixin extends DirectionalBlock implements BlockSubLevelAssemblyListener {
+
+    @Shadow
+    public abstract boolean stillValid(BlockGetter level, BlockPos pos, BlockState state, boolean directlyAdjacent);
+
+    protected WaterWheelStructuralBlockMixin(Properties p_52591_) {
+        super(p_52591_);
+    }
+
+    public void afterMove(final ServerLevel originLevel, final ServerLevel resultingLevel, final BlockState newState, final BlockPos oldPos, final BlockPos newPos) {
+    }
+
+    @Override
+    public void afterAssemble(final ServerLevel originLevel, final ServerLevel resultingLevel, final BlockState newState, final BlockPos oldPos, final BlockPos newPos) {
+        if (!this.stillValid(resultingLevel, newPos, newState, false)) {
+            resultingLevel.setBlockAndUpdate(newPos, Blocks.AIR.defaultBlockState());
+        }
+    }
+
+}

--- a/neoforge/src/main/resources/sable-neoforge.mixins.json
+++ b/neoforge/src/main/resources/sable-neoforge.mixins.json
@@ -159,6 +159,7 @@
     "compatibility.create.tracks.TrackPlacementMixin",
     "compatibility.create.turntable.TurntableBlockMixin",
     "compatibility.create.vertical_gearbox.VerticalGearboxItemMixin",
+    "compatibility.create.water_wheel_structure.WaterWheelStructuralBlockMixin",
     "compatibility.create.zapper.ZapperItemMixin",
     "compatibility.pmweather.AnemometerBlockEntityMixin",
     "compatibility.pmweather.AnemometerBlockMixin",


### PR DESCRIPTION
Adds `afterAssemble` to `BlockSubLevelAssemblyListener`, a hook that can be used to revalidate structure blocks, after the sublevel assembly is complete, but early enough that blocks can be removed without showing a sublevel.

*(A similar less intrusive change would be to schedule a block tick after assembly, but as mentioned this means a sublevel is there for a tick til the structure is revalidated)*

Fixes #236

# Before

<img width="742" height="653" alt="image" src="https://github.com/user-attachments/assets/433c20a2-373d-480f-922f-9482e9f9dec6" />
<img width="678" height="590" alt="image" src="https://github.com/user-attachments/assets/bc116f9e-4f43-41e1-b9ef-d661704bc829" />

# After
<img width="406" height="288" alt="image" src="https://github.com/user-attachments/assets/f0385511-b973-49b9-b984-26306b9d70e4" />
<img width="470" height="343" alt="image" src="https://github.com/user-attachments/assets/17391e6e-5bdc-43c5-b56e-0532b4cad62b" />
