### PR TITLE
Add ability to put physics constraints on any PhysicsPipelineBody

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/api/physics/PhysicsPipeline.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/physics/PhysicsPipeline.java
@@ -221,6 +221,17 @@ public interface PhysicsPipeline {
      * @param configuration the configuration of the constraint
      */
     default <T extends PhysicsConstraintHandle> T addConstraint(@Nullable final ServerSubLevel sublevelA, @Nullable final ServerSubLevel sublevelB, final PhysicsConstraintConfiguration<T> configuration) {
+        return this.addConstraint((PhysicsPipelineBody)sublevelA, sublevelB, configuration);
+    }
+
+    /**
+     * Adds a constraint to the engine, returning its handle
+     *
+     * @param rigidbodyA    the first rigid-body to constrain, or null to constrain the second rigid-body to the world
+     * @param rigidbodyB    the second rigid-body to constrain, or null to constrain the first rigid-body to the world
+     * @param configuration the configuration of the constraint
+     */
+    default <T extends PhysicsConstraintHandle> T addConstraint(@Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final PhysicsConstraintConfiguration<T> configuration) {
         throw new UnsupportedOperationException("Not implemented");
     }
 

--- a/common/src/main/java/dev/ryanhcode/sable/api/physics/PhysicsPipeline.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/physics/PhysicsPipeline.java
@@ -221,17 +221,17 @@ public interface PhysicsPipeline {
      * @param configuration the configuration of the constraint
      */
     default <T extends PhysicsConstraintHandle> T addConstraint(@Nullable final ServerSubLevel sublevelA, @Nullable final ServerSubLevel sublevelB, final PhysicsConstraintConfiguration<T> configuration) {
-        return this.addConstraint((PhysicsPipelineBody)sublevelA, sublevelB, configuration);
+        return this.addConstraint((PhysicsPipelineBody) sublevelA, sublevelB, configuration);
     }
 
     /**
      * Adds a constraint to the engine, returning its handle
      *
-     * @param rigidbodyA    the first rigid-body to constrain, or null to constrain the second rigid-body to the world
-     * @param rigidbodyB    the second rigid-body to constrain, or null to constrain the first rigid-body to the world
+     * @param bodyA         the first rigid-body to constrain, or null to constrain the second rigid-body to the world
+     * @param bodyB         the second rigid-body to constrain, or null to constrain the first rigid-body to the world
      * @param configuration the configuration of the constraint
      */
-    default <T extends PhysicsConstraintHandle> T addConstraint(@Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final PhysicsConstraintConfiguration<T> configuration) {
+    default <T extends PhysicsConstraintHandle> T addConstraint(@Nullable final PhysicsPipelineBody bodyA, @Nullable final PhysicsPipelineBody bodyB, final PhysicsConstraintConfiguration<T> configuration) {
         throw new UnsupportedOperationException("Not implemented");
     }
 

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/RapierPhysicsPipeline.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/RapierPhysicsPipeline.java
@@ -620,37 +620,37 @@ public class RapierPhysicsPipeline implements PhysicsPipeline {
     /**
      * Adds a constraint to the engine, returning its handle
      *
-     * @param sublevelA     the first sub-level to constrain, or null to constrain the second sub-level to the world
-     * @param sublevelB     the second sub-level to constrain, or null to constrain the first sub-level to the world
+     * @param rigidbodyA    the first body to constrain, or null to constrain the second body to the world
+     * @param rigidbodyB    the second body to constrain, or null to constrain the first body to the world
      * @param configuration the configuration of the constraint
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends PhysicsConstraintHandle> T addConstraint(@Nullable final ServerSubLevel sublevelA, @Nullable final ServerSubLevel sublevelB, final PhysicsConstraintConfiguration<T> configuration) {
-        if (sublevelA == null && sublevelB == null) {
+    public <T extends PhysicsConstraintHandle> T addConstraint(@Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final PhysicsConstraintConfiguration<T> configuration) {
+        if (rigidbodyA == null && rigidbodyB == null) {
             Sable.LOGGER.error("Cannot add a constraint between the static world and static world", new Throwable("Stack Trace"));
             return null;
         }
 
-        if (sublevelA == sublevelB) {
+        if (rigidbodyA == rigidbodyB) {
             Sable.LOGGER.error("Cannot add a constraint between a sub-level and itself", new Throwable("Stack Trace"));
             return null;
         }
 
         if (configuration instanceof final RotaryConstraintConfiguration config) {
-            return (T) RapierRotaryConstraintHandle.create(this.level, sublevelA, sublevelB, config);
+            return (T) RapierRotaryConstraintHandle.create(this.level, rigidbodyA, rigidbodyB, config);
         }
 
         if (configuration instanceof final FixedConstraintConfiguration config) {
-            return (T) RapierFixedConstraintHandle.create(this.level, sublevelA, sublevelB, config);
+            return (T) RapierFixedConstraintHandle.create(this.level, rigidbodyA, rigidbodyB, config);
         }
 
         if (configuration instanceof final FreeConstraintConfiguration config) {
-            return (T) RapierFreeConstraintHandle.create(this.level, sublevelA, sublevelB, config);
+            return (T) RapierFreeConstraintHandle.create(this.level, rigidbodyA, rigidbodyB, config);
         }
 
         if (configuration instanceof final GenericConstraintConfiguration config) {
-            return (T) RapierGenericConstraintHandle.create(this.level, sublevelA, sublevelB, config);
+            return (T) RapierGenericConstraintHandle.create(this.level, rigidbodyA, rigidbodyB, config);
         }
 
         Sable.LOGGER.error("Unknown constraint configuration type: {}", configuration.getClass().getName());

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/RapierPhysicsPipeline.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/RapierPhysicsPipeline.java
@@ -620,37 +620,37 @@ public class RapierPhysicsPipeline implements PhysicsPipeline {
     /**
      * Adds a constraint to the engine, returning its handle
      *
-     * @param rigidbodyA    the first body to constrain, or null to constrain the second body to the world
-     * @param rigidbodyB    the second body to constrain, or null to constrain the first body to the world
+     * @param bodyA         the first rigid-body to constrain, or null to constrain the second rigid-body to the world
+     * @param bodyB         the second rigid-body to constrain, or null to constrain the first rigid-body to the world
      * @param configuration the configuration of the constraint
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends PhysicsConstraintHandle> T addConstraint(@Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final PhysicsConstraintConfiguration<T> configuration) {
-        if (rigidbodyA == null && rigidbodyB == null) {
+    public <T extends PhysicsConstraintHandle> T addConstraint(@Nullable final PhysicsPipelineBody bodyA, @Nullable final PhysicsPipelineBody bodyB, final PhysicsConstraintConfiguration<T> configuration) {
+        if (bodyA == null && bodyB == null) {
             Sable.LOGGER.error("Cannot add a constraint between the static world and static world", new Throwable("Stack Trace"));
             return null;
         }
 
-        if (rigidbodyA == rigidbodyB) {
+        if (bodyA == bodyB) {
             Sable.LOGGER.error("Cannot add a constraint between a sub-level and itself", new Throwable("Stack Trace"));
             return null;
         }
 
         if (configuration instanceof final RotaryConstraintConfiguration config) {
-            return (T) RapierRotaryConstraintHandle.create(this.level, rigidbodyA, rigidbodyB, config);
+            return (T) RapierRotaryConstraintHandle.create(this.level, bodyA, bodyB, config);
         }
 
         if (configuration instanceof final FixedConstraintConfiguration config) {
-            return (T) RapierFixedConstraintHandle.create(this.level, rigidbodyA, rigidbodyB, config);
+            return (T) RapierFixedConstraintHandle.create(this.level, bodyA, bodyB, config);
         }
 
         if (configuration instanceof final FreeConstraintConfiguration config) {
-            return (T) RapierFreeConstraintHandle.create(this.level, rigidbodyA, rigidbodyB, config);
+            return (T) RapierFreeConstraintHandle.create(this.level, bodyA, bodyB, config);
         }
 
         if (configuration instanceof final GenericConstraintConfiguration config) {
-            return (T) RapierGenericConstraintHandle.create(this.level, rigidbodyA, rigidbodyB, config);
+            return (T) RapierGenericConstraintHandle.create(this.level, bodyA, bodyB, config);
         }
 
         Sable.LOGGER.error("Unknown constraint configuration type: {}", configuration.getClass().getName());

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/fixed/RapierFixedConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/fixed/RapierFixedConstraintHandle.java
@@ -12,13 +12,13 @@ public class RapierFixedConstraintHandle extends RapierConstraintHandle implemen
     /**
      * Creates a rapier constraint handle
      */
-    public static RapierFixedConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final FixedConstraintConfiguration config) {
+    public static RapierFixedConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody bodyA, @Nullable final PhysicsPipelineBody bodyB, final FixedConstraintConfiguration config) {
         final int sceneID = Rapier3D.getID(serverLevel);
 
         final long handle = Rapier3D.addFixedConstraint(
                 sceneID,
-                rigidbodyA == null ? -1 : Rapier3D.getID(rigidbodyA),
-                rigidbodyB == null ? -1 : Rapier3D.getID(rigidbodyB),
+                bodyA == null ? -1 : Rapier3D.getID(bodyA),
+                bodyB == null ? -1 : Rapier3D.getID(bodyB),
                 config.pos1().x(),
                 config.pos1().y(),
                 config.pos1().z(),

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/fixed/RapierFixedConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/fixed/RapierFixedConstraintHandle.java
@@ -1,10 +1,10 @@
 package dev.ryanhcode.sable.physics.impl.rapier.constraint.fixed;
 
+import dev.ryanhcode.sable.api.physics.PhysicsPipelineBody;
 import dev.ryanhcode.sable.api.physics.constraint.fixed.FixedConstraintConfiguration;
 import dev.ryanhcode.sable.api.physics.constraint.fixed.FixedConstraintHandle;
 import dev.ryanhcode.sable.physics.impl.rapier.Rapier3D;
 import dev.ryanhcode.sable.physics.impl.rapier.constraint.RapierConstraintHandle;
-import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,13 +12,13 @@ public class RapierFixedConstraintHandle extends RapierConstraintHandle implemen
     /**
      * Creates a rapier constraint handle
      */
-    public static RapierFixedConstraintHandle create(final ServerLevel serverLevel, @Nullable final ServerSubLevel sublevelA, @Nullable final ServerSubLevel sublevelB, final FixedConstraintConfiguration config) {
+    public static RapierFixedConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final FixedConstraintConfiguration config) {
         final int sceneID = Rapier3D.getID(serverLevel);
 
         final long handle = Rapier3D.addFixedConstraint(
                 sceneID,
-                sublevelA == null ? -1 :  Rapier3D.getID(sublevelA),
-                sublevelB == null ? -1 :  Rapier3D.getID(sublevelB),
+                rigidbodyA == null ? -1 : Rapier3D.getID(rigidbodyA),
+                rigidbodyB == null ? -1 : Rapier3D.getID(rigidbodyB),
                 config.pos1().x(),
                 config.pos1().y(),
                 config.pos1().z(),

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/free/RapierFreeConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/free/RapierFreeConstraintHandle.java
@@ -12,13 +12,13 @@ public class RapierFreeConstraintHandle extends RapierConstraintHandle implement
     /**
      * Creates a rapier constraint handle
      */
-    public static RapierFreeConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final FreeConstraintConfiguration config) {
+    public static RapierFreeConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody bodyA, @Nullable final PhysicsPipelineBody bodyB, final FreeConstraintConfiguration config) {
         final int sceneID = Rapier3D.getID(serverLevel);
 
         final long handle = Rapier3D.addFreeConstraint(
                 sceneID,
-                rigidbodyA == null ? -1 : Rapier3D.getID(rigidbodyA),
-                rigidbodyB == null ? -1 : Rapier3D.getID(rigidbodyB),
+                bodyA == null ? -1 : Rapier3D.getID(bodyA),
+                bodyB == null ? -1 : Rapier3D.getID(bodyB),
                 config.pos1().x(),
                 config.pos1().y(),
                 config.pos1().z(),

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/free/RapierFreeConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/free/RapierFreeConstraintHandle.java
@@ -1,10 +1,10 @@
 package dev.ryanhcode.sable.physics.impl.rapier.constraint.free;
 
+import dev.ryanhcode.sable.api.physics.PhysicsPipelineBody;
 import dev.ryanhcode.sable.api.physics.constraint.free.FreeConstraintConfiguration;
 import dev.ryanhcode.sable.api.physics.constraint.free.FreeConstraintHandle;
 import dev.ryanhcode.sable.physics.impl.rapier.Rapier3D;
 import dev.ryanhcode.sable.physics.impl.rapier.constraint.RapierConstraintHandle;
-import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,13 +12,13 @@ public class RapierFreeConstraintHandle extends RapierConstraintHandle implement
     /**
      * Creates a rapier constraint handle
      */
-    public static RapierFreeConstraintHandle create(final ServerLevel serverLevel, @Nullable final ServerSubLevel sublevelA, @Nullable final ServerSubLevel sublevelB, final FreeConstraintConfiguration config) {
+    public static RapierFreeConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final FreeConstraintConfiguration config) {
         final int sceneID = Rapier3D.getID(serverLevel);
 
         final long handle = Rapier3D.addFreeConstraint(
                 sceneID,
-                sublevelA == null ? -1 :  Rapier3D.getID(sublevelA),
-                sublevelB == null ? -1 :  Rapier3D.getID(sublevelB),
+                rigidbodyA == null ? -1 : Rapier3D.getID(rigidbodyA),
+                rigidbodyB == null ? -1 : Rapier3D.getID(rigidbodyB),
                 config.pos1().x(),
                 config.pos1().y(),
                 config.pos1().z(),

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/generic/RapierGenericConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/generic/RapierGenericConstraintHandle.java
@@ -1,11 +1,11 @@
 package dev.ryanhcode.sable.physics.impl.rapier.constraint.generic;
 
+import dev.ryanhcode.sable.api.physics.PhysicsPipelineBody;
 import dev.ryanhcode.sable.api.physics.constraint.ConstraintJointAxis;
 import dev.ryanhcode.sable.api.physics.constraint.generic.GenericConstraintConfiguration;
 import dev.ryanhcode.sable.api.physics.constraint.generic.GenericConstraintHandle;
 import dev.ryanhcode.sable.physics.impl.rapier.Rapier3D;
 import dev.ryanhcode.sable.physics.impl.rapier.constraint.RapierConstraintHandle;
-import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -21,7 +21,7 @@ public class RapierGenericConstraintHandle extends RapierConstraintHandle implem
     /**
      * Creates a rapier constraint handle
      */
-    public static RapierGenericConstraintHandle create(final ServerLevel serverLevel, @Nullable final ServerSubLevel sublevelA, @Nullable final ServerSubLevel sublevelB, final GenericConstraintConfiguration config) {
+    public static RapierGenericConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final GenericConstraintConfiguration config) {
         final int sceneID = Rapier3D.getID(serverLevel);
 
         int lockedAxesMask = 0;
@@ -31,8 +31,8 @@ public class RapierGenericConstraintHandle extends RapierConstraintHandle implem
 
         final long handle = Rapier3D.addGenericConstraint(
                 sceneID,
-                sublevelA == null ? -1 : Rapier3D.getID(sublevelA),
-                sublevelB == null ? -1 : Rapier3D.getID(sublevelB),
+                rigidbodyA == null ? -1 : Rapier3D.getID(rigidbodyA),
+                rigidbodyB == null ? -1 : Rapier3D.getID(rigidbodyB),
                 config.pos1().x(),
                 config.pos1().y(),
                 config.pos1().z(),

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/generic/RapierGenericConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/generic/RapierGenericConstraintHandle.java
@@ -21,7 +21,7 @@ public class RapierGenericConstraintHandle extends RapierConstraintHandle implem
     /**
      * Creates a rapier constraint handle
      */
-    public static RapierGenericConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final GenericConstraintConfiguration config) {
+    public static RapierGenericConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody bodyA, @Nullable final PhysicsPipelineBody bodyB, final GenericConstraintConfiguration config) {
         final int sceneID = Rapier3D.getID(serverLevel);
 
         int lockedAxesMask = 0;
@@ -31,8 +31,8 @@ public class RapierGenericConstraintHandle extends RapierConstraintHandle implem
 
         final long handle = Rapier3D.addGenericConstraint(
                 sceneID,
-                rigidbodyA == null ? -1 : Rapier3D.getID(rigidbodyA),
-                rigidbodyB == null ? -1 : Rapier3D.getID(rigidbodyB),
+                bodyA == null ? -1 : Rapier3D.getID(bodyA),
+                bodyB == null ? -1 : Rapier3D.getID(bodyB),
                 config.pos1().x(),
                 config.pos1().y(),
                 config.pos1().z(),

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/rotary/RapierRotaryConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/rotary/RapierRotaryConstraintHandle.java
@@ -1,10 +1,10 @@
 package dev.ryanhcode.sable.physics.impl.rapier.constraint.rotary;
 
+import dev.ryanhcode.sable.api.physics.PhysicsPipelineBody;
 import dev.ryanhcode.sable.api.physics.constraint.rotary.RotaryConstraintConfiguration;
 import dev.ryanhcode.sable.api.physics.constraint.rotary.RotaryConstraintHandle;
 import dev.ryanhcode.sable.physics.impl.rapier.Rapier3D;
 import dev.ryanhcode.sable.physics.impl.rapier.constraint.RapierConstraintHandle;
-import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,13 +12,13 @@ public class RapierRotaryConstraintHandle extends RapierConstraintHandle impleme
     /**
      * Creates a rapier constraint handle
      */
-    public static RapierRotaryConstraintHandle create(final ServerLevel serverLevel, @Nullable final ServerSubLevel sublevelA, @Nullable final ServerSubLevel sublevelB, final RotaryConstraintConfiguration config) {
+    public static RapierRotaryConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final RotaryConstraintConfiguration config) {
         final int sceneID = Rapier3D.getID(serverLevel);
 
         final long handle = Rapier3D.addRotaryConstraint(
                 sceneID,
-                sublevelA == null ? -1 :  Rapier3D.getID(sublevelA),
-                sublevelB == null ? -1 :  Rapier3D.getID(sublevelB),
+                rigidbodyA == null ? -1 : Rapier3D.getID(rigidbodyA),
+                rigidbodyB == null ? -1 : Rapier3D.getID(rigidbodyB),
                 config.pos1().x(),
                 config.pos1().y(),
                 config.pos1().z(),

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/rotary/RapierRotaryConstraintHandle.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/constraint/rotary/RapierRotaryConstraintHandle.java
@@ -12,13 +12,13 @@ public class RapierRotaryConstraintHandle extends RapierConstraintHandle impleme
     /**
      * Creates a rapier constraint handle
      */
-    public static RapierRotaryConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody rigidbodyA, @Nullable final PhysicsPipelineBody rigidbodyB, final RotaryConstraintConfiguration config) {
+    public static RapierRotaryConstraintHandle create(final ServerLevel serverLevel, @Nullable final PhysicsPipelineBody bodyA, @Nullable final PhysicsPipelineBody bodyB, final RotaryConstraintConfiguration config) {
         final int sceneID = Rapier3D.getID(serverLevel);
 
         final long handle = Rapier3D.addRotaryConstraint(
                 sceneID,
-                rigidbodyA == null ? -1 : Rapier3D.getID(rigidbodyA),
-                rigidbodyB == null ? -1 : Rapier3D.getID(rigidbodyB),
+                bodyA == null ? -1 : Rapier3D.getID(bodyA),
+                bodyB == null ? -1 : Rapier3D.getID(bodyB),
                 config.pos1().x(),
                 config.pos1().y(),
                 config.pos1().z(),

--- a/common/src/main/rust/rapier/src/joints.rs
+++ b/common/src/main/rust/rapier/src/joints.rs
@@ -70,16 +70,11 @@ pub fn tick(scene_id: jint) {
             ));
         }
         let local_anchor_1 = joint.pos_a
-            - if let Some(id_a) = joint.id_a {
-                if let Some(rb_a) = scene.level_colliders.get(&id_a) {
-                    rb_a.center_of_mass.unwrap()
-                }
-                else {
-                    Vector3::new(0.0, 0.0, 0.0)
-                }
-            } else {
-                Vector3::new(0.0, 0.0, 0.0)
-            };
+            - joint
+                .id_a
+                .and_then(|id| scene.level_colliders.get(&id))
+                .and_then(|rb| rb.center_of_mass)
+                .unwrap_or_default();
         impulse_joint.data.set_local_anchor1(Vector::new(
             local_anchor_1.x as Real,
             local_anchor_1.y as Real,
@@ -93,16 +88,11 @@ pub fn tick(scene_id: jint) {
             ));
         }
         let local_anchor_2 = joint.pos_b
-            - if let Some(id_b) = joint.id_b {
-                if let Some(rb_b) = scene.level_colliders.get(&id_b) {
-                    rb_b.center_of_mass.unwrap()
-                }
-                else {
-                    Vector3::new(0.0, 0.0, 0.0)
-                }
-            } else {
-                Vector3::new(0.0, 0.0, 0.0)
-            };
+            - joint
+                .id_b
+                .and_then(|id| scene.level_colliders.get(&id))
+                .and_then(|rb| rb.center_of_mass)
+                .unwrap_or_default();
         impulse_joint.data.set_local_anchor2(Vector::new(
             local_anchor_2.x as Real,
             local_anchor_2.y as Real,

--- a/common/src/main/rust/rapier/src/joints.rs
+++ b/common/src/main/rust/rapier/src/joints.rs
@@ -72,8 +72,8 @@ pub fn tick(scene_id: jint) {
         let local_anchor_1 = joint.pos_a
             - joint
                 .id_a
-                .and_then(|id| scene.level_colliders.get(&id))
-                .and_then(|rb| rb.center_of_mass)
+                .and_then(|v| scene.level_colliders.get(&v))
+                .map(|v| v.center_of_mass.unwrap())
                 .unwrap_or_default();
         impulse_joint.data.set_local_anchor1(Vector::new(
             local_anchor_1.x as Real,
@@ -90,8 +90,8 @@ pub fn tick(scene_id: jint) {
         let local_anchor_2 = joint.pos_b
             - joint
                 .id_b
-                .and_then(|id| scene.level_colliders.get(&id))
-                .and_then(|rb| rb.center_of_mass)
+                .and_then(|v| scene.level_colliders.get(&v))
+                .map(|v| v.center_of_mass.unwrap())
                 .unwrap_or_default();
         impulse_joint.data.set_local_anchor2(Vector::new(
             local_anchor_2.x as Real,

--- a/common/src/main/rust/rapier/src/joints.rs
+++ b/common/src/main/rust/rapier/src/joints.rs
@@ -71,8 +71,12 @@ pub fn tick(scene_id: jint) {
         }
         let local_anchor_1 = joint.pos_a
             - if let Some(id_a) = joint.id_a {
-                let rb_a = &scene.level_colliders[&id_a];
-                rb_a.center_of_mass.unwrap()
+                if let Some(rb_a) = scene.level_colliders.get(&id_a) {
+                    rb_a.center_of_mass.unwrap()
+                }
+                else {
+                    Vector3::new(0.0, 0.0, 0.0)
+                }
             } else {
                 Vector3::new(0.0, 0.0, 0.0)
             };
@@ -90,8 +94,12 @@ pub fn tick(scene_id: jint) {
         }
         let local_anchor_2 = joint.pos_b
             - if let Some(id_b) = joint.id_b {
-                let rb_b = &scene.level_colliders[&id_b];
-                rb_b.center_of_mass.unwrap()
+                if let Some(rb_b) = scene.level_colliders.get(&id_b) {
+                    rb_b.center_of_mass.unwrap()
+                }
+                else {
+                    Vector3::new(0.0, 0.0, 0.0)
+                }
             } else {
                 Vector3::new(0.0, 0.0, 0.0)
             };


### PR DESCRIPTION
Allow `PhysicsPipelineBody` as arguments of `addConstraint`.

The motivation is to allow addons to be able to add physically constrained rigid-bodies through `BoxPhysicsObject` instead of sub-levels as `BoxPhysicsObject` is easier to manage.

Since instances of `BoxPhysicsObject` aren't added to the set of level colliders, this requires getting the local center of mass of rigid-bodies to also default to the zero position vector if they are not found in the set.