### PR TITLE
fix: prevent NPE when Camera.entity is null

### DIFF
--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/camera_rotation/CameraMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/camera_rotation/CameraMixin.java
@@ -69,6 +69,10 @@ public abstract class CameraMixin {
 
     @WrapMethod(method = "setPosition(Lnet/minecraft/world/phys/Vec3;)V")
     private void sable$setPosition(final Vec3 arg, final Operation<Void> original) {
+        if (this.entity == null) {
+            original.call(arg);
+            return;
+        }
         final Level level = this.entity.level();
 
         final ClientSubLevel subLevel = (ClientSubLevel) Sable.HELPER.getContaining(level, arg);


### PR DESCRIPTION
Leawind‘s Third Person may temporarily set camera entity to null, causing Sable to crash at entity.level().

Add null check and fallback to original behavior.