### PR TITLE
Partially validate respawn for loaded/deleted sublevels

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/respawn_point/ServerPlayerMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/respawn_point/ServerPlayerMixin.java
@@ -169,7 +169,16 @@ public abstract class ServerPlayerMixin implements ServerPlayerRespawnExtension 
                 return Optional.empty();
             }
 
-            // TODO: do validation here
+            // Skip validation when the sublevel is unloaded
+            final boolean shouldValidate = point.subLevelId() == null || Sable.HELPER.getContaining(level, blockPos) != null;
+
+            if (shouldValidate && findRespawnAndUseSpawnBlock(level, blockPos, f1, b1, b2).isEmpty()) {
+                data.removeTrackingPoint(this.sable$respawnPoint);
+                this.sable$respawnPoint = null;
+                return Optional.empty();
+            }
+
+            // TODO: validation for unloaded sublevels
 
             if (point.subLevelId() != null) {
                 this.sable$queuedFreeze = Pair.of(point.subLevelId(), point.localAnchor());


### PR DESCRIPTION
Partial fix for #200 

If the sublevel is loaded or deleted, we try to check for beds/respawn anchors.
Unloaded sublevels are out of scope of this PR.

This partial solution means players aren't stuck in infinite death loops if say their airship falls into the void in dimensions without the void sea.
