### PR TITLE
Add musl-linked Rapier natives for Alpine Linux

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,3 @@
+ - Ship musl-linked Rapier natives for Alpine Linux (`*_linux_musl.so`) alongside glibc builds
  - Fix issues with glibc support on Linux Sable Rapier natives
  - Fix Create Blueprints not working on sub-levels

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,6 +22,10 @@ def linux(arch) {
     [triple: "${arch}-unknown-linux-gnu", suffix: ".2.17", arch: arch, os: "linux", ext: "so", lib: true]
 }
 
+def linuxMusl(arch) {
+    [triple: "${arch}-unknown-linux-musl", suffix: "", arch: arch, os: "linux_musl", ext: "so", lib: true]
+}
+
 def freebsd(arch) {
     [triple: "${arch}-unknown-freebsd", suffix: "", arch: arch, os: "freebsd", ext: "so", lib: true]
 }
@@ -35,6 +39,8 @@ def supportedTargets = [
         mac("aarch64"),
         linux("x86_64"),
         linux("aarch64"),
+        linuxMusl("x86_64"),
+        linuxMusl("aarch64"),
         windows("x86_64"),
         windows("aarch64"),
 //        freebsd("x86_64"),

--- a/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/impl/rapier/Rapier3D.java
@@ -15,6 +15,7 @@ import org.joml.Matrix3dc;
 import org.joml.Vector3dc;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,6 +41,25 @@ public class Rapier3D {
         loadLibrary();
     }
 
+    /**
+     * Alpine and other musl-based Linux distros need a separate .so from glibc ({@code *_linux.so}) builds.
+     */
+    private static boolean isLinuxMusl() {
+        if (Util.getPlatform() != OS.LINUX) {
+            return false;
+        }
+        if (Files.exists(Paths.get("/lib/ld-musl-x86_64.so.1"))
+                || Files.exists(Paths.get("/lib/ld-musl-aarch64.so.1"))
+                || Files.exists(Paths.get("/lib64/ld-musl-x86_64.so.1"))) {
+            return true;
+        }
+        try {
+            return Files.readString(Paths.get("/proc/self/maps")).contains("libc.musl-");
+        } catch (final IOException ignored) {
+            return false;
+        }
+    }
+
     private static String getNativeName() {
         final String arch;
         if (System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").startsWith("aarch64")) {
@@ -56,6 +76,9 @@ public class Rapier3D {
         } else {
             if (os != OS.LINUX)
                 Sable.LOGGER.error("Unknown platform '{}' detected, sable will attempt to use linux natives, this may or may not work.", System.getProperty("os.name"));
+            if (isLinuxMusl()) {
+                return LIB_NAME + "_" + arch + "_linux_musl.so";
+            }
             return LIB_NAME + "_" + arch + "_linux.so";
         }
     }

--- a/common/src/main/rust/.cargo/config.toml
+++ b/common/src/main/rust/.cargo/config.toml
@@ -4,3 +4,10 @@ rustflags = ["-C", "link-arg=-Wl,-Brepro"]
 [target.x86_64-apple-darwin]
 # Required to avoid a rustc hang when building for this target.
 rustflags = ["-C", "codegen-units=2"]
+
+# JNI cdylibs must link libc dynamically on musl (default is static crt).
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/common/src/main/rust/container/zigbuild/Dockerfile
+++ b/common/src/main/rust/container/zigbuild/Dockerfile
@@ -7,6 +7,8 @@ RUN rustup target add x86_64-apple-darwin
 RUN rustup target add aarch64-apple-darwin
 RUN rustup target add x86_64-unknown-linux-gnu
 RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup target add x86_64-unknown-linux-musl
+RUN rustup target add aarch64-unknown-linux-musl
 RUN rustup target add x86_64-unknown-freebsd
 # used for AArch64 FreeBSD
 #RUN rustup component add rust-src


### PR DESCRIPTION
Closes #13.

On musl-based Linux (e.g. Alpine in Docker), the server reported:

Sable has failed to load the natives needed for its Rapier pipeline. Native library name sable_rapier_x86_64_linux.so.
Linux artifacts were only built for *-unknown-linux-gnu (glibc). Alpine’s dynamic linker and libc are musl, so the existing *_linux.so binaries are not loadable there even though the architecture is still x86_64.

While debugging the same environment, this also appeared in the log:

[common.asm.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/multiplayer/ClientLevel for invalid dist DEDICATED_SERVER
That message comes from loading a client-only class on a dedicated server (distribution / classloading). It is not fixed by shipping musl natives; if it persists after this change, it should be tracked and fixed separately.

Solution:

- Cross-compile Rapier JNI for x86_64-unknown-linux-musl and aarch64-unknown-linux-musl, package them as sable_rapier_<arch>_linux_musl.so, and include them in sable_rapier_binaries.zip.l4z alongside the existing glibc *_linux.so builds (common/build.gradle).
- Install the musl Rust targets in the zigbuild Docker image (common/src/main/rust/container/zigbuild/Dockerfile).
- Set -C target-feature=-crt-static for musl targets so the JNI cdylib links dynamically against libc (required for System.load JNI libraries) (common/src/main/rust/.cargo/config.toml).
- At runtime, detect musl and load …_linux_musl.so; otherwise keep loading …_linux.so (Rapier3D.java).

Note:
Maintainers must rebuild the zigbuild image and run common:buildRustNatives (or CI equivalent) so published jars contain the new zip entries; old builds without *_linux_musl.so will still fail on Alpine.
