### PR TITLE
Make rust building tasks configuration cache friendly

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,3 +1,11 @@
 plugins {
     id 'groovy-gradle-plugin'
 }
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'at.yawk.lz4:lz4-java:1.11.0'
+}

--- a/buildSrc/src/main/groovy/Lz4CompressTask.groovy
+++ b/buildSrc/src/main/groovy/Lz4CompressTask.groovy
@@ -1,0 +1,37 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import net.jpountz.lz4.LZ4FrameOutputStream
+import java.nio.file.Files
+
+abstract class Lz4CompressTask extends DefaultTask {
+
+    @InputFile
+    abstract RegularFileProperty getInputJar()
+
+    @OutputFile
+    abstract RegularFileProperty getOutputJar()
+
+    @TaskAction
+    void compress() {
+        def inputFile = inputJar.get().asFile
+        def outputFile = outputJar.get().asFile
+
+        byte[] bytes = Files.readAllBytes(inputFile.toPath())
+
+        outputFile.parentFile.mkdirs()
+
+        new FileOutputStream(outputFile).withCloseable { fos ->
+            new LZ4FrameOutputStream(
+                    fos,
+                    LZ4FrameOutputStream.BLOCKSIZE.SIZE_4MB,
+                    bytes.length,
+                    LZ4FrameOutputStream.FLG.Bits.BLOCK_INDEPENDENCE
+            ).withCloseable { lz4 ->
+                lz4.write(bytes)
+            }
+        }
+    }
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,12 +3,6 @@ import net.jpountz.lz4.LZ4FrameOutputStream
 
 import java.nio.file.Files
 
-buildscript {
-    dependencies {
-        classpath 'at.yawk.lz4:lz4-java:1.11.0'
-    }
-}
-
 plugins {
     id 'multiloader-common'
     id 'net.neoforged.moddev'
@@ -116,7 +110,7 @@ def commandLineForTarget(target) {
     }
 }
 
-def nativesNameForTarget(target) {
+static def nativesNameForTarget(Map<String, Object> target) {
     "sable_rapier_${target.arch}_${target.os}.${target.ext}"
 }
 
@@ -125,7 +119,7 @@ supportedTargets.forEach { target ->
         group = 'rust'
         workingDir rustProjectDir
         description = "Cross-compiles natives for the ${target.triple} target"
-        def commands= commandLineForTarget(target)
+        def commands = commandLineForTarget(target)
         commands.add('--release')
         commandLine = commands
     }
@@ -160,8 +154,9 @@ tasks.register('copyRustNatives', Copy) {
     mustRunAfter(buildRustNatives)
 
     supportedTargets.forEach { target ->
+        def nativeName = nativesNameForTarget(target)
         from(file("$rustRootDir/target/${target.triple}/release/${if (target.lib) { "lib" } else { "" }}sable_rapier.${target.ext}")) {
-            rename { nativesNameForTarget(target) }
+            rename { nativeName }
         }
     }
     finalizedBy packRustNatives
@@ -194,16 +189,24 @@ tasks.register('packRustNatives', Zip) {
         // No, you can't use rename here in case you were wondering.
         from(file("${nativesDir}/${f}")) { eachFile { setPath f } }
     }
-    doLast {
-        byte[] bytes = Files.readAllBytes(getArchiveFile().get().asFile.toPath())
-        try (var f = new FileOutputStream(getArchiveFile().get().asFile)) {
-            try (var x = new LZ4FrameOutputStream(f, LZ4FrameOutputStream.BLOCKSIZE.SIZE_4MB, bytes.length, LZ4FrameOutputStream.FLG.Bits.BLOCK_INDEPENDENCE)) {
-                x.write(bytes)
-            }
-        }
-        supportedTargets.forEach { t ->
-            delete(file("${nativesDir}/${nativesNameForTarget(t)}"))
-        }
+
+    finalizedBy(compressLZ4)
+}
+
+tasks.register('compressLZ4', Lz4CompressTask) {
+    dependsOn cleanOldNatives
+
+    def packTask = tasks.named("packRustNatives")
+    dependsOn packTask
+    def file = packTask.get().getArchiveFile()
+
+    inputJar.set(file)
+    outputJar.set(file)
+}
+
+tasks.register('cleanOldNatives', Delete) {
+    supportedTargets.forEach { t ->
+        delete(nativesDir.toPath().resolve(nativesNameForTarget(t)))
     }
 }
 


### PR DESCRIPTION
This PR adds dedicate Task and switches from using `doLast`. This is to make it configuration cache friendly.
I did not enable configuration cache in gradle.properties because I'm not sure if there is any other incompatible task.
But in my testing I could launch Minecraft and build rust natives with no problem when it was enabled.