### PR TITLE
Fix Breeze charges not affecting contraptions

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/explosion/ExplosionMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/explosion/ExplosionMixin.java
@@ -19,7 +19,7 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.projectile.windcharge.WindCharge;
+import net.minecraft.world.entity.projectile.windcharge.AbstractWindCharge;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.ExplosionDamageCalculator;
 import net.minecraft.world.level.Level;
@@ -135,7 +135,7 @@ public class ExplosionMixin {
                             set.add(blockpos);
                         }
 
-                        final boolean wind = this.source instanceof WindCharge && !blockstate.isAir();
+                        final boolean wind = this.source instanceof AbstractWindCharge && !blockstate.isAir();
                         if (canExplodeBefore && (f < 0.0f || wind) && explodedSet.get().add(blockpos)) {
                             explodedSet.get().add(blockpos);
 


### PR DESCRIPTION
Breeze charges are instanceof `BreezeWindCharge`, not `WindCharge`. By checking their common super class, `AbstractWindCharge`, we can support both kinds of wind charges to affect contraptions.

Partially fixes #618.