### PR TITLE
Fix nether portal linking (#793): don't scale Y by dimension multiplier

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/portal/NetherPortalBlockMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/portal/NetherPortalBlockMixin.java
@@ -28,7 +28,7 @@ public class NetherPortalBlockMixin {
 
         return instance.clampToBounds(
                 globalPos.x * multiplier,
-                globalPos.y * multiplier,
+                globalPos.y,
                 globalPos.z * multiplier
         );
     }


### PR DESCRIPTION
Fixes #793

Problem
NetherPortalBlockMixin applies the dimension coordinate multiplier (8x for Nether→Overworld, 0.125x for Overworld→Nether) to all three axes (X, Y, Z) when calculating the portal destination target position. Vanilla Minecraft only scales X and Z — the Y coordinate is never scaled by the dimension multiplier.

This causes the portal search target to have a wildly incorrect Y value (e.g., Y=118 becomes Y=944 when going Nether→Overworld), resulting in the game selecting the wrong destination portal.

Fix
Remove * multiplier from the Y coordinate in the clampToBounds call (line 31 of NetherPortalBlockMixin.java).

Tested
Verified fix resolves the issue in both singleplayer and multiplayer. Portal linking now correctly selects the closest portal by Euclidean distance, matching vanilla behavior.