### PR TITLE
Fix standing up from crawling

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/player_standup/PlayerMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/player_standup/PlayerMixin.java
@@ -1,0 +1,32 @@
+package dev.ryanhcode.sable.mixin.player_standup;
+
+import dev.ryanhcode.sable.mixinhelpers.CanFallAtleastHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Player.class)
+public class PlayerMixin {
+
+    @Redirect(
+            method = "canPlayerFitWithinBlocksAndEntitiesWhen",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/Level;noCollision(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Z"
+            )
+    )
+    private boolean sable$noCollisionWithSubLevels(final Level level, final Entity entity, final AABB aabb) {
+        final boolean original = level.noCollision(entity, aabb);
+
+        if (!original) return false;
+
+        // If vanilla says no collision, also check sublevel blocks.
+        // canFallAtleastWithSubLevels returns non-null when there IS a collision,
+        // meaning the player does NOT fit → return false.
+        return CanFallAtleastHelper.canFallAtleastWithSubLevels(level, aabb) == null;
+    }
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/player_standup/PlayerMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/player_standup/PlayerMixin.java
@@ -1,5 +1,7 @@
 package dev.ryanhcode.sable.mixin.player_standup;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.ryanhcode.sable.mixinhelpers.CanFallAtleastHelper;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -7,26 +9,25 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Player.class)
 public class PlayerMixin {
 
-    @Redirect(
+    @WrapOperation(
             method = "canPlayerFitWithinBlocksAndEntitiesWhen",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/world/level/Level;noCollision(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Z"
             )
     )
-    private boolean sable$noCollisionWithSubLevels(final Level level, final Entity entity, final AABB aabb) {
-        final boolean original = level.noCollision(entity, aabb);
-
-        if (!original) return false;
+    private boolean sable$noCollisionWithSubLevels(final Level instance, final Entity entity, final AABB aabb, final Operation<Boolean> original) {
+        if (!original.call(instance, entity, aabb)) {
+            return false;
+        }
 
         // If vanilla says no collision, also check sublevel blocks.
         // canFallAtleastWithSubLevels returns non-null when there IS a collision,
         // meaning the player does NOT fit → return false.
-        return CanFallAtleastHelper.canFallAtleastWithSubLevels(level, aabb) == null;
+        return CanFallAtleastHelper.canFallAtleastWithSubLevels(instance, aabb) == null;
     }
 }

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -50,6 +50,7 @@
     "particle.SuspendedParticleMixin",
     "particle.TerrainParticleMixin",
     "player_freezing.LocalPlayerMixin",
+    "player_standup.PlayerMixin",
     "plot.ClientChunkCacheMixin",
     "plot.MinecraftMixin",
     "plot.lighting.ClientPacketListenerMixin",


### PR DESCRIPTION
I'm going to deploy this fork to a private server for testing, but this fixed the issue in my initial testing for both:
- when entering crawling via a trapdoor on the main level, then crawling under a sable sublevel
- when entering crawling via a trapdoor while on a sable sublevel