### PR TITLE
Fixed a bug that duplicated items. 

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/api/SubLevelAssemblyHelper.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/SubLevelAssemblyHelper.java
@@ -354,7 +354,7 @@ public class SubLevelAssemblyHelper {
                 if (blockEntity instanceof final Clearable clearable) {
                     clearable.clearContent();
                 }else if (blockEntity != null) {
-                    SableAssemblyPlatform.INSTANCE.clearNonClearableContainerItems(blockEntity);
+                    SableAssemblyPlatform.INSTANCE.clearNonClearableContainerItems(blockEntity,tag);
                 }
 
                 final LevelChunk chunk = resultingAccelerator.getChunk(SectionPos.blockToSectionCoord(newPos.getX()), SectionPos.blockToSectionCoord(newPos.getZ()));

--- a/common/src/main/java/dev/ryanhcode/sable/api/SubLevelAssemblyHelper.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/SubLevelAssemblyHelper.java
@@ -353,6 +353,8 @@ public class SubLevelAssemblyHelper {
                 }
                 if (blockEntity instanceof final Clearable clearable) {
                     clearable.clearContent();
+                }else if (blockEntity != null) {
+                    SableAssemblyPlatform.INSTANCE.clearNonClearableContainerItems(blockEntity);
                 }
 
                 final LevelChunk chunk = resultingAccelerator.getChunk(SectionPos.blockToSectionCoord(newPos.getX()), SectionPos.blockToSectionCoord(newPos.getZ()));

--- a/common/src/main/java/dev/ryanhcode/sable/platform/SableAssemblyPlatform.java
+++ b/common/src/main/java/dev/ryanhcode/sable/platform/SableAssemblyPlatform.java
@@ -1,5 +1,6 @@
 package dev.ryanhcode.sable.platform;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.ApiStatus;
@@ -10,5 +11,5 @@ public interface SableAssemblyPlatform {
 
     void setIgnoreOnPlace(final Level level, final boolean ignore);
 
-    void clearNonClearableContainerItems(final BlockEntity blockEntity);
+    void clearNonClearableContainerItems(final BlockEntity blockEntity,final CompoundTag tag);
 }

--- a/common/src/main/java/dev/ryanhcode/sable/platform/SableAssemblyPlatform.java
+++ b/common/src/main/java/dev/ryanhcode/sable/platform/SableAssemblyPlatform.java
@@ -1,6 +1,7 @@
 package dev.ryanhcode.sable.platform;
 
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
@@ -8,4 +9,6 @@ public interface SableAssemblyPlatform {
     SableAssemblyPlatform INSTANCE = SablePlatformUtil.load(SableAssemblyPlatform.class);
 
     void setIgnoreOnPlace(final Level level, final boolean ignore);
+
+    void clearNonClearableContainerItems(final BlockEntity blockEntity);
 }

--- a/fabric/src/main/java/dev/ryanhcode/sable/fabric/platform/SableAssemblyPlatformImpl.java
+++ b/fabric/src/main/java/dev/ryanhcode/sable/fabric/platform/SableAssemblyPlatformImpl.java
@@ -2,8 +2,12 @@ package dev.ryanhcode.sable.fabric.platform;
 
 import dev.ryanhcode.sable.fabric.mixinterface.LevelExtension;
 import dev.ryanhcode.sable.platform.SableAssemblyPlatform;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.ApiStatus;
+import java.util.ArrayList;
+import java.util.List;
 
 @ApiStatus.Internal
 public class SableAssemblyPlatformImpl implements SableAssemblyPlatform {
@@ -11,5 +15,34 @@ public class SableAssemblyPlatformImpl implements SableAssemblyPlatform {
     @Override
     public void setIgnoreOnPlace(final Level level, final boolean ignore) {
         ((LevelExtension) level).sable$setIgnoreOnPlace(ignore);
+    }
+
+    @Override
+    public void clearNonClearableContainerItems(final BlockEntity blockEntity) {
+        if (blockEntity == null) {
+            return;
+        }
+        try {
+            final Level level = blockEntity.getLevel();
+            if (level == null) {
+                return;
+            }
+            final CompoundTag tag = blockEntity.saveWithFullMetadata(level.registryAccess());
+            if (tag.isEmpty()) {
+                return;
+            }
+            final List<String> keysToRemove = new ArrayList<>();
+            for (final String key : tag.getAllKeys()) {
+                if (!key.equals("id")) {
+                    keysToRemove.add(key);
+                }
+            }
+            for (final String key : keysToRemove) {
+                tag.remove(key);
+            }
+            blockEntity.loadWithComponents(tag, level.registryAccess());
+        } catch (final Exception ignored) {
+
+        }
     }
 }

--- a/fabric/src/main/java/dev/ryanhcode/sable/fabric/platform/SableAssemblyPlatformImpl.java
+++ b/fabric/src/main/java/dev/ryanhcode/sable/fabric/platform/SableAssemblyPlatformImpl.java
@@ -6,8 +6,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.ApiStatus;
-import java.util.ArrayList;
-import java.util.List;
 
 @ApiStatus.Internal
 public class SableAssemblyPlatformImpl implements SableAssemblyPlatform {
@@ -18,31 +16,14 @@ public class SableAssemblyPlatformImpl implements SableAssemblyPlatform {
     }
 
     @Override
-    public void clearNonClearableContainerItems(final BlockEntity blockEntity) {
-        if (blockEntity == null) {
-            return;
-        }
+    public void clearNonClearableContainerItems(final BlockEntity blockEntity,final CompoundTag tag) {
         try {
             final Level level = blockEntity.getLevel();
-            if (level == null) {
-                return;
-            }
-            final CompoundTag tag = blockEntity.saveWithFullMetadata(level.registryAccess());
-            if (tag.isEmpty()) {
-                return;
-            }
-            final List<String> keysToRemove = new ArrayList<>();
-            for (final String key : tag.getAllKeys()) {
-                if (!key.equals("id")) {
-                    keysToRemove.add(key);
-                }
-            }
-            for (final String key : keysToRemove) {
-                tag.remove(key);
-            }
-            blockEntity.loadWithComponents(tag, level.registryAccess());
-        } catch (final Exception ignored) {
-
-        }
+            if (level == null) return;
+            final String id = tag.getString("id");
+            final CompoundTag newTag = new CompoundTag();
+            newTag.putString("id", id);
+            blockEntity.loadWithComponents(newTag, level.registryAccess());
+        } catch (final Exception ignored) {}
     }
 }

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/platform/SableAssemblyPlatformImpl.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/platform/SableAssemblyPlatformImpl.java
@@ -5,8 +5,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.ApiStatus;
-import java.util.ArrayList;
-import java.util.List;
 
 @ApiStatus.Internal
 public class SableAssemblyPlatformImpl implements SableAssemblyPlatform {
@@ -18,30 +16,14 @@ public class SableAssemblyPlatformImpl implements SableAssemblyPlatform {
 
     @Override
     public void clearNonClearableContainerItems(final BlockEntity blockEntity) {
-        if (blockEntity == null) {
-            return;
-        }
         try {
             final Level level = blockEntity.getLevel();
-            if (level == null) {
-                return;
-            }
-            final CompoundTag tag = blockEntity.saveWithFullMetadata(level.registryAccess());
-            if (tag.isEmpty()) {
-                return;
-            }
-            final List<String> keysToRemove = new ArrayList<>();
-            for (final String key : tag.getAllKeys()) {
-                if (!key.equals("id")) {
-                    keysToRemove.add(key);
-                }
-            }
-            for (final String key : keysToRemove) {
-                tag.remove(key);
-            }
-            blockEntity.loadWithComponents(tag, level.registryAccess());
-        } catch (final Exception ignored) {
-
-        }
+            if (level == null) return;
+            final CompoundTag oldTag = blockEntity.saveWithFullMetadata(level.registryAccess());
+            final String id = oldTag.getString("id");
+            final CompoundTag newTag = new CompoundTag();
+            newTag.putString("id", id);
+            blockEntity.loadWithComponents(newTag, level.registryAccess());
+        } catch (final Exception ignored) {}
     }
 }

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/platform/SableAssemblyPlatformImpl.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/platform/SableAssemblyPlatformImpl.java
@@ -15,12 +15,11 @@ public class SableAssemblyPlatformImpl implements SableAssemblyPlatform {
     }
 
     @Override
-    public void clearNonClearableContainerItems(final BlockEntity blockEntity) {
+    public void clearNonClearableContainerItems(final BlockEntity blockEntity,final CompoundTag tag) {
         try {
             final Level level = blockEntity.getLevel();
             if (level == null) return;
-            final CompoundTag oldTag = blockEntity.saveWithFullMetadata(level.registryAccess());
-            final String id = oldTag.getString("id");
+            final String id = tag.getString("id");
             final CompoundTag newTag = new CompoundTag();
             newTag.putString("id", id);
             blockEntity.loadWithComponents(newTag, level.registryAccess());

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/platform/SableAssemblyPlatformImpl.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/platform/SableAssemblyPlatformImpl.java
@@ -1,8 +1,12 @@
 package dev.ryanhcode.sable.neoforge.platform;
 
 import dev.ryanhcode.sable.platform.SableAssemblyPlatform;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.ApiStatus;
+import java.util.ArrayList;
+import java.util.List;
 
 @ApiStatus.Internal
 public class SableAssemblyPlatformImpl implements SableAssemblyPlatform {
@@ -10,5 +14,34 @@ public class SableAssemblyPlatformImpl implements SableAssemblyPlatform {
     @Override
     public void setIgnoreOnPlace(final Level level, final boolean ignore) {
         level.captureBlockSnapshots = ignore;
+    }
+
+    @Override
+    public void clearNonClearableContainerItems(final BlockEntity blockEntity) {
+        if (blockEntity == null) {
+            return;
+        }
+        try {
+            final Level level = blockEntity.getLevel();
+            if (level == null) {
+                return;
+            }
+            final CompoundTag tag = blockEntity.saveWithFullMetadata(level.registryAccess());
+            if (tag.isEmpty()) {
+                return;
+            }
+            final List<String> keysToRemove = new ArrayList<>();
+            for (final String key : tag.getAllKeys()) {
+                if (!key.equals("id")) {
+                    keysToRemove.add(key);
+                }
+            }
+            for (final String key : keysToRemove) {
+                tag.remove(key);
+            }
+            blockEntity.loadWithComponents(tag, level.registryAccess());
+        } catch (final Exception ignored) {
+
+        }
     }
 }


### PR DESCRIPTION
The bug was: when an item was placed on a Table Cloth, using the Physics Assembler would cause the item to be duplicated. The fix was based on the fact that blocks like Table Cloth are not registered as clearable, so an additional method was written to handle blocks not registered as clearable. The implementation approach is to directly initialize the block's NBT, retaining only its own ID, since it will be removed soon.
This is my first time using a pull request. I'm not sure if my fix is a good solution, but it should be useful.