### PR TITLE
Fix minecarts disappearing when derailing on sublevel

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entities_stick_sublevels/ClientPacketListenerMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entities_stick_sublevels/ClientPacketListenerMixin.java
@@ -105,7 +105,8 @@ public abstract class ClientPacketListenerMixin {
             if (subLevel != null && actuallyInSubLevel && existingSubLevel != subLevel) {
                 entity.setPos(subLevel.logicalPose().transformPositionInverse(entity.position()));
             } else if (existingSubLevel != null && subLevel == null) {
-                entity.setPos(existingSubLevel.logicalPose().transformPosition(entity.position()));
+                final Vec3 newPos = existingSubLevel.logicalPose().transformPosition(entity.position());
+                entity.moveTo(newPos.x, newPos.y, newPos.z);
             }
 
             entity.lerpTo(pX, pY, pZ, pYRot, pXRot, pLerpSteps);

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/AbstractMinecartMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/AbstractMinecartMixin.java
@@ -3,14 +3,12 @@ package dev.ryanhcode.sable.mixin.entity.entity_sublevel_collision;
 import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.api.entity.EntitySubLevelUtil;
 import dev.ryanhcode.sable.sublevel.SubLevel;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.BaseRailBlock;
-import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -22,16 +20,16 @@ public abstract class AbstractMinecartMixin extends Entity {
         super(entityType, level);
     }
 
+    @Shadow public abstract boolean isOnRails();
+
     @Inject(method = "tick", at = @At("TAIL"))
     private void sable$postTick(final CallbackInfo ci) {
+        if (this.level().isClientSide) return;
+
         final SubLevel containingSubLevel = Sable.HELPER.getContaining(this);
         if (containingSubLevel == null) return;
 
-        final BlockPos pos = this.blockPosition();
-        final BlockState here = this.level().getBlockState(pos);
-        final BlockState below = this.level().getBlockState(pos.below());
-
-        if (BaseRailBlock.isRail(here) || BaseRailBlock.isRail(below)) return;
+        if (this.isOnRails()) return;
 
         EntitySubLevelUtil.kickEntity(containingSubLevel, this);
     }

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/AbstractMinecartMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/AbstractMinecartMixin.java
@@ -1,12 +1,15 @@
 package dev.ryanhcode.sable.mixin.entity.entity_sublevel_collision;
 
 import dev.ryanhcode.sable.Sable;
-import dev.ryanhcode.sable.index.SableTags;
+import dev.ryanhcode.sable.api.entity.EntitySubLevelUtil;
 import dev.ryanhcode.sable.sublevel.SubLevel;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BaseRailBlock;
+import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -15,22 +18,21 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(AbstractMinecart.class)
 public abstract class AbstractMinecartMixin extends Entity {
 
-
     public AbstractMinecartMixin(final EntityType<?> entityType, final Level level) {
         super(entityType, level);
     }
 
     @Inject(method = "tick", at = @At("TAIL"))
     private void sable$postTick(final CallbackInfo ci) {
-        if (!this.getType().is(SableTags.DESTROY_WHEN_LEAVING_PLOT)) {
-            return;
-        }
-
         final SubLevel containingSubLevel = Sable.HELPER.getContaining(this);
+        if (containingSubLevel == null) return;
 
-        // Destroy us if we're in #sable:destroy_when_leaving_plot and we've left the plot
-        if (containingSubLevel != null && !this.getBoundingBox().intersects(containingSubLevel.getPlot().getBoundingBox().toAABB().inflate(0.5))) {
-            this.kill();
-        }
+        final BlockPos pos = this.blockPosition();
+        final BlockState here = this.level().getBlockState(pos);
+        final BlockState below = this.level().getBlockState(pos.below());
+
+        if (BaseRailBlock.isRail(here) || BaseRailBlock.isRail(below)) return;
+
+        EntitySubLevelUtil.kickEntity(containingSubLevel, this);
     }
 }


### PR DESCRIPTION
`AbstractMinecartMixin`: when a cart isn't on rails anymore (`!isOnRails()`), kick it back to world space right away instead of waiting for it to leave plot bounds and killing it. Server-only.

`ClientPacketListenerMixin.sable$lerp`: the sub-level to world branch was using `setPos`, which doesn't touch `xo/yo/zo`. That caused a one-frame flicker since rendering would interpolate between shipyard and world coords, drawing the entity at a ~15M block midpoint. Swapped it for `moveTo`. Fixes the flicker for any entity, not just minecarts.

Minecart entries in `destroy_when_leaving_plot.json` aren't used anymore.