### PR TITLE
Fix for lag and errors occurring when an entity is teleported to a sublevel

### DIFF
--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/entity/entity_collisions/EntityMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/entity/entity_collisions/EntityMixin.java
@@ -1,0 +1,21 @@
+package dev.ryanhcode.sable.neoforge.mixin.entity.entity_collisions;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import dev.ryanhcode.sable.Sable;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Entity.class)
+public class EntityMixin {
+
+    // Projects the target delta out of a sublevel when looking up solid entity collisions. This fixes teleporting to sublevels causing insane amounts of lag.
+    @WrapOperation(method = "collide", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/AABB;expandTowards(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/AABB;"))
+    public AABB sublevelEntityCollisionFix(final AABB instance, final Vec3 vector, final Operation<AABB> original) {
+        final var entity = (Entity)(Object) this;
+        return original.call(instance, Sable.HELPER.projectOutOfSubLevel(entity.level(), entity.position().add(vector)));
+    }
+}

--- a/neoforge/src/main/resources/sable-neoforge.mixins.json
+++ b/neoforge/src/main/resources/sable-neoforge.mixins.json
@@ -167,6 +167,7 @@
     "compatibility.pmweather.AnemometerBlockMixin",
     "compatibility.pmweather.PMWeatherMixin",
     "entities_stick_sublevels.effects.LivingEntityMixin",
+    "entity.entity_collisions.EntityMixin",
     "entity.entity_swimming.EntityMixin"
   ],
   "injectors": {


### PR DESCRIPTION
Fixed entity collider looking for solid entity collisions from the colliding entity's position all the way to the shipyard plot's world position when teleporting to a sublevel. This is done by injecting code into `Entity.collide` that projects the delta vector out of the sublevel its in right before it gets passed onto `Level.getEntityCollisions`

This fixes issue #283 