### PR TITLE
Configurable sub-level assembly height (#938)

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/SableConfig.java
+++ b/common/src/main/java/dev/ryanhcode/sable/SableConfig.java
@@ -3,6 +3,7 @@ package dev.ryanhcode.sable;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 public final class SableConfig {
+    public enum SubLevelStartPos { FIXED, DYNAMIC, MIDPOINT }
 
     public static final ModConfigSpec SPEC;
 
@@ -19,6 +20,8 @@ public final class SableConfig {
     public static final ModConfigSpec.BooleanValue ATTEMPT_UDP_NETWORKING;
     public static final ModConfigSpec.BooleanValue VERBOSE_SERIALIZATION_LOGGING;
     public static final ModConfigSpec.BooleanValue SUB_LEVEL_SAVING_LOG_MESSAGE;
+    public static final ModConfigSpec.EnumValue<SubLevelStartPos> SUB_LEVEL_START_POS;
+    public static final ModConfigSpec.IntValue SUB_LEVEL_FIXED_START_HEIGHT;
 
     static {
         final ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
@@ -64,6 +67,12 @@ public final class SableConfig {
         VERBOSE_SERIALIZATION_LOGGING = builder
                 .comment("If Sable should use verbose logging for its serialization system and the holding chunk-map. Not recommended- for debugging purposes only.")
                 .define("verbose_serialization_logging", false);
+        SUB_LEVEL_START_POS = builder
+                .comment("When a sub-level is created, how to determine the height within the sub-level that the first block should be placed at.")
+                .defineEnum("sub_level_start_pos", SubLevelStartPos.FIXED);
+        SUB_LEVEL_FIXED_START_HEIGHT = builder
+                .comment("If 'sub_level_start_pos' is set to 'FIXED', the fixed height to use.")
+                .defineInRange("sub_level_fixed_start_height", 128, Integer.MIN_VALUE, Integer.MAX_VALUE);
 
         SPEC = builder.build();
     }

--- a/common/src/main/java/dev/ryanhcode/sable/api/SubLevelAssemblyHelper.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/SubLevelAssemblyHelper.java
@@ -1,6 +1,7 @@
 package dev.ryanhcode.sable.api;
 
 import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.SableConfig;
 import dev.ryanhcode.sable.api.block.BlockSubLevelAssemblyListener;
 import dev.ryanhcode.sable.api.physics.PhysicsPipeline;
 import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
@@ -84,7 +85,14 @@ public class SubLevelAssemblyHelper {
         final LevelPlot plot = subLevel.getPlot();
         plot.newEmptyChunk(plot.getCenterChunk());
 
-        final BlockPos plotAnchor = plot.getCenterBlock();
+        Integer yPos = 128;
+        switch (SableConfig.SUB_LEVEL_START_POS.get()) {
+                case FIXED -> yPos = SableConfig.SUB_LEVEL_FIXED_START_HEIGHT.getAsInt();
+                case DYNAMIC -> yPos = anchor.getY();
+                case MIDPOINT -> yPos = (level.getMinBuildHeight() + level.getMaxBuildHeight()) >> 1;
+        }
+
+        final BlockPos plotAnchor = plot.getCenterBlock().atY(yPos);
         final SubLevelAssemblyHelper.AssemblyTransform transform = new SubLevelAssemblyHelper.AssemblyTransform(anchor, plotAnchor, 0, Rotation.NONE, level);
         SubLevelAssemblyHelper.moveOtherStuff(level, transform, blocks, bounds);
         SubLevelAssemblyHelper.moveBlocks(level, transform, blocks);


### PR DESCRIPTION
Adds 2 config values, implementing suggestions 2 & 3 from #938:
- SUB_LEVEL_FIXED_START_HEIGHT: If SUB_LEVEL_START_POS is set to FIXED, then this is the height (Default value of 128 matches the current approach)
- SUB_LEVEL_START_POS: Determines the approach to use for determining the height (Y value) of the first block in a newly assembled sub-level (FIXED, DYNAMIC, MIDPOINT)
  - FIXED: Uses the height specified by SUB_LEVEL_FIXED_START_HEIGHT (Essentially the current approach)
  - DYNAMIC: Uses the world height of the position the block is in (Spawn a sub-level at Y=73, the block is placed at Y=73 in the sub-level)
  - MIDPOINT: Calculates the midpoint between the min and max build limits, then uses that as the height

Defaults are 128 and FIXED, to match the current approach exactly, with all the customization being exclusively opt-in.

----

With dynamic assembly height, a 1-block sub-level created at Y=87 has its sole block located at Y=87 within the sub-level
<img width="1920" height="653" alt="image" src="https://github.com/user-attachments/assets/eb3e3768-0064-44f3-a902-d3931b20660a" />
