### PR TITLE
Fix armor stands disappearing when falling off sub-levels

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entities_stick_sublevels/ClientPacketListenerMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entities_stick_sublevels/ClientPacketListenerMixin.java
@@ -103,9 +103,11 @@ public abstract class ClientPacketListenerMixin {
             final SubLevel existingSubLevel = Sable.HELPER.getContaining(this.level, entity.position());
 
             if (subLevel != null && actuallyInSubLevel && existingSubLevel != subLevel) {
-                entity.setPos(subLevel.logicalPose().transformPositionInverse(entity.position()));
+                final Vec3 newPos = subLevel.logicalPose().transformPositionInverse(entity.position());
+                entity.moveTo(newPos.x, newPos.y, newPos.z);
             } else if (existingSubLevel != null && subLevel == null) {
-                entity.setPos(existingSubLevel.logicalPose().transformPosition(entity.position()));
+                final Vec3 newPos = existingSubLevel.logicalPose().transformPosition(entity.position());
+                entity.moveTo(newPos.x, newPos.y, newPos.z);
             }
 
             entity.lerpTo(pX, pY, pZ, pYRot, pXRot, pLerpSteps);

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_rendering/LevelRendererMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_rendering/LevelRendererMixin.java
@@ -44,7 +44,7 @@ public class LevelRendererMixin {
                                         @Local(ordinal = 5) final LocalDoubleRef entityZ,
                                         @Share("renderPose") final LocalRef<Pose3dc> renderPoseShare) {
         // Render the entity on the data
-        final ClientSubLevel subLevel = (ClientSubLevel) Sable.HELPER.getContaining(entity);
+        final ClientSubLevel subLevel = Sable.HELPER.getContainingClient(entity.getX(), entity.getZ());
 
         if (subLevel == null) {
             // Tracking sub-levels

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/ArmorStandMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/ArmorStandMixin.java
@@ -1,0 +1,33 @@
+package dev.ryanhcode.sable.mixin.entity.entity_sublevel_collision;
+
+import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.api.entity.EntitySubLevelUtil;
+import dev.ryanhcode.sable.sublevel.SubLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ArmorStand.class)
+public abstract class ArmorStandMixin extends Entity {
+
+    public ArmorStandMixin(final EntityType<?> entityType, final Level level) {
+        super(entityType, level);
+    }
+
+    @Inject(method = "tick", at = @At("TAIL"))
+    private void sable$postTick(final CallbackInfo ci) {
+        if (this.level().isClientSide) return;
+
+        final SubLevel containingSubLevel = Sable.HELPER.getContaining(this);
+        if (containingSubLevel == null) return;
+
+        if (this.onGround()) return;
+
+        EntitySubLevelUtil.kickEntity(containingSubLevel, this);
+    }
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/ArmorStandMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/ArmorStandMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -24,10 +25,19 @@ public abstract class ArmorStandMixin extends Entity {
         if (this.level().isClientSide) return;
 
         final SubLevel containingSubLevel = Sable.HELPER.getContaining(this);
-        if (containingSubLevel == null) return;
 
-        if (this.onGround()) return;
-
-        EntitySubLevelUtil.kickEntity(containingSubLevel, this);
+        if (containingSubLevel != null) {
+            if (!this.onGround()) {
+                EntitySubLevelUtil.kickEntity(containingSubLevel, this);
+            }
+        } else if (this.onGround()) {
+            final SubLevel landed = Sable.HELPER.getTrackingSubLevel(this);
+            if (landed != null) {
+                final Vec3 shipyardPos = landed.logicalPose().transformPositionInverse(this.position());
+                final Vec3 shipyardVel = landed.logicalPose().transformNormalInverse(this.getDeltaMovement());
+                this.moveTo(shipyardPos.x, shipyardPos.y, shipyardPos.z);
+                this.setDeltaMovement(shipyardVel);
+            }
+        }
     }
 }

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/ArmorStandMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/ArmorStandMixin.java
@@ -8,7 +8,11 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -20,6 +24,9 @@ public abstract class ArmorStandMixin extends Entity {
         super(entityType, level);
     }
 
+    @Unique
+    private int sable$lastAttachedTick;
+
     @Inject(method = "tick", at = @At("TAIL"))
     private void sable$postTick(final CallbackInfo ci) {
         if (this.level().isClientSide) return;
@@ -27,16 +34,22 @@ public abstract class ArmorStandMixin extends Entity {
         final SubLevel containingSubLevel = Sable.HELPER.getContaining(this);
 
         if (containingSubLevel != null) {
-            if (!this.onGround()) {
+            if (this.tickCount - this.sable$lastAttachedTick > 1 && !this.onGround()) {
                 EntitySubLevelUtil.kickEntity(containingSubLevel, this);
             }
         } else if (this.onGround()) {
             final SubLevel landed = Sable.HELPER.getTrackingSubLevel(this);
             if (landed != null) {
                 final Vec3 shipyardPos = landed.logicalPose().transformPositionInverse(this.position());
-                final Vec3 shipyardVel = landed.logicalPose().transformNormalInverse(this.getDeltaMovement());
-                this.moveTo(shipyardPos.x, shipyardPos.y, shipyardPos.z);
-                this.setDeltaMovement(shipyardVel);
+                final BlockPos belowPos = BlockPos.containing(shipyardPos.x, shipyardPos.y - 0.5, shipyardPos.z);
+                final BlockState belowState = this.level().getBlockState(belowPos);
+                if (belowState.isFaceSturdy(this.level(), belowPos, Direction.UP)
+                        && Math.abs(shipyardPos.y - (belowPos.getY() + 1)) < 0.1) {
+                    final Vec3 shipyardVel = landed.logicalPose().transformNormalInverse(this.getDeltaMovement());
+                    this.moveTo(shipyardPos.x, shipyardPos.y, shipyardPos.z);
+                    this.setDeltaMovement(shipyardVel);
+                    this.sable$lastAttachedTick = this.tickCount;
+                }
             }
         }
     }

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/no_culling/EntityMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/no_culling/EntityMixin.java
@@ -1,0 +1,22 @@
+package dev.ryanhcode.sable.mixin.entity.no_culling;
+
+import dev.ryanhcode.sable.api.entity.EntitySubLevelUtil;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Entity.class)
+public abstract class EntityMixin {
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void sable$disableCullingForRetained(final EntityType<?> type, final Level level, final CallbackInfo ci) {
+        final Entity self = (Entity) (Object) this;
+        if (!EntitySubLevelUtil.shouldKick(self)) {
+            self.noCulling = true;
+        }
+    }
+}

--- a/common/src/main/resources/data/sable/tags/entity_type/destroy_when_leaving_plot.json
+++ b/common/src/main/resources/data/sable/tags/entity_type/destroy_when_leaving_plot.json
@@ -2,7 +2,6 @@
   "replace": false,
   "values": [
     { "id": "exposure:camera_stand", "required": false },
-    "minecraft:armor_stand",
     "minecraft:minecart",
     "minecraft:hopper_minecart",
     "minecraft:chest_minecart",

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -149,6 +149,7 @@
     "entity.entity_rotations_and_riding.ServerEntityMixin",
     "entity.entity_rotations_and_riding.ServerPlayerMixin",
     "entity.entity_sublevel_collision.AbstractMinecartMixin",
+    "entity.entity_sublevel_collision.ArmorStandMixin",
     "entity.entity_sublevel_collision.EntityMixin",
     "entity.entity_sublevel_collision.ItemEntityMixin",
     "entity.entity_sublevel_collision.LevelMixin",

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -41,6 +41,7 @@
     "entity.entity_sublevel_collision.CameraMixin",
     "entity.entity_swimming.CameraMixin",
     "entity.parrot.ParrotMixin",
+    "entity.no_culling.EntityMixin",
     "loaded_chunk_debug.BlockUpdatePacketMixin",
     "loaded_chunk_debug.ChunkBorderRendererMixin",
     "loaded_chunk_debug.ClientChunkCacheStorageAccessor",


### PR DESCRIPTION
New `ArmorStandMixin` mirrors the minecart fix: when an armor stand is in a sub-level and not on the ground, kick it back to world space instead of letting it fall through shipyard and eventually get killed by the leave-plot tag. Server-only.

`destroy_when_leaving_plot.json` no longer needs the armor stand entry.