### PR TITLE
Fix dynamic breaking distance check (solves #401)

### DIFF
--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/behaviour_compatibility/block_breaking_behaviour/BlockBreakingMovementBehaviourMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/behaviour_compatibility/block_breaking_behaviour/BlockBreakingMovementBehaviourMixin.java
@@ -76,7 +76,8 @@ public abstract class BlockBreakingMovementBehaviourMixin implements MovementBeh
                     targetCenter = targetSubLevel.logicalPose().transformPosition(targetCenter);
                 }
 
-                if (sublevelLocalCenter.distanceToSqr(targetCenter) > 2 * 2) {
+                final double allowDistanceSqr = this.getActiveAreaOffset(context).lengthSqr() + 1;
+                if (sublevelLocalCenter.distanceToSqr(targetCenter) > allowDistanceSqr ) {
                     data.remove("Progress");
                     data.remove("TicksUntilNextProgress");
                     data.remove("BreakingPos");

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/behaviour_compatibility/block_breaking_behaviour/BlockBreakingMovementBehaviourMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/behaviour_compatibility/block_breaking_behaviour/BlockBreakingMovementBehaviourMixin.java
@@ -3,6 +3,7 @@ package dev.ryanhcode.sable.neoforge.mixin.compatibility.create.behaviour_compat
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.content.contraptions.actors.roller.RollerMovementBehaviour;
 import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 import com.simibubi.create.content.kinetics.base.BlockBreakingMovementBehaviour;
 import dev.ryanhcode.sable.ActiveSableCompanion;
@@ -54,6 +55,10 @@ public abstract class BlockBreakingMovementBehaviourMixin implements MovementBeh
 
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     public void sable$testBreakingPosDist(final MovementContext context, final CallbackInfo ci) {
+        if ((Object) this instanceof RollerMovementBehaviour) {
+            return;
+        }
+
         final CompoundTag data = context.data;
         if (data.contains("BreakingPos") || data.contains("LastPos")) {
             final BlockPos blockPos = NbtUtils.readBlockPos(data, "BreakingPos").orElseGet(() -> NbtUtils.readBlockPos(data, "LastPos").orElse(null));


### PR DESCRIPTION
This PR fixed #401 by add a dynamic breaking distance check as the default. For most cases, the breaking distance is now calculated contextually rather than using hardcoded rules. And also use PR #970 approach to  preserving compatibility with other mods which use roller replace blocks far away.

This should resolve the core issue reliably while preserving compatibility with other mods.

Let me know if more tests or adjustments are needed!