### PR TITLE
Fix collision issues on sub-levels with dying entities

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/EntityMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/entity/entity_sublevel_collision/EntityMixin.java
@@ -108,8 +108,23 @@ public abstract class EntityMixin implements EntityMovementExtension {
 
     @Redirect(method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;collide(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;"))
     public Vec3 sable$collideRedirect(final Entity entity, final Vec3 collisionMotion) {
+        final double MAX_MOTION = 10.0;
+        final Vec3 clampedMotion = (Math.abs(collisionMotion.x) > MAX_MOTION ||
+                Math.abs(collisionMotion.y) > MAX_MOTION ||
+                Math.abs(collisionMotion.z) > MAX_MOTION)
+                ? Vec3.ZERO
+                : collisionMotion;
+
+        if (entity.isRemoved()
+                || (entity instanceof LivingEntity living && living.isDeadOrDying())) {
+            this.sable$collisionInfo = new SubLevelEntityCollision.CollisionInfo();
+            this.sable$collisionInfo.motion = clampedMotion;
+            this.sable$trackingSubLevel = null;
+            return this.collide(clampedMotion);
+        }
+
         final Entity self = (Entity) (Object) this;
-        final Vec3 motion = collisionMotion;
+        final Vec3 motion = clampedMotion;
 
         Vec3 velocity = Vec3.ZERO;
 


### PR DESCRIPTION
When a player dies inside of a pair of Create's Crushing Wheels while standing on/in a sub-level, the server would either crash or delay the respawn of the dead player, causing them to wait in the respawn screen for quite a while. This is due to the velocity given to an entity colliding with a crushing wheel if on the ground by Create.

This PR should fix the issue where it would delay the player's respawn and it should return normal coordinates and not exceed any AABB limits.

Fixes #593