### PR TITLE
Tagify block properties

### DIFF
--- a/common/src/main/resources/data/sable/physics_block_properties/end_stone_slabs.json
+++ b/common/src/main/resources/data/sable/physics_block_properties/end_stone_slabs.json
@@ -1,5 +1,5 @@
 {
-  "selector": "minecraft:end_stone_brick_slab",
+  "selector": "#sable:end_stone_slabs",
 
   "properties": {
     "sable:floating_material": "sable:end_stone",

--- a/common/src/main/resources/data/sable/tags/block/end_stone_slabs.json
+++ b/common/src/main/resources/data/sable/tags/block/end_stone_slabs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:end_stone_brick_slab"
+  ]
+}


### PR DESCRIPTION
so far `#sable:end_stone_slabs` instead of just having the `minecraft:end_stone_brick_slab`