### PR TITLE
Prevent lightning on sublevels

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/stop_lightning/ServerLevelMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/stop_lightning/ServerLevelMixin.java
@@ -1,0 +1,29 @@
+package dev.ryanhcode.sable.mixin.stop_lightning;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Prevents lightning or skeleton traps from spawning inside plots to avoid inflating spawn rates
+ */
+@Mixin(ServerLevel.class)
+public class ServerLevelMixin {
+
+    @WrapOperation(method="tickChunk", at=@At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;isThundering()Z"))
+    private boolean sable$preventLightningInPlot(final ServerLevel instance, final Operation<Boolean> original, @Local(argsOnly = true) final LevelChunk chunk) {
+        final SubLevelContainer plotContainer = SubLevelContainer.getContainer((ServerLevel) (Object) this);
+        assert plotContainer != null;
+
+        if (plotContainer.getPlot(chunk.getPos()) != null) {
+            return false;
+        }
+        return original.call(instance);
+    }
+
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/stop_lightning/ServerLevelMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/stop_lightning/ServerLevelMixin.java
@@ -4,26 +4,44 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
+import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.storage.WritableLevelData;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import java.util.function.Supplier;
 
 /**
  * Prevents lightning or skeleton traps from spawning inside plots to avoid inflating spawn rates
  */
 @Mixin(ServerLevel.class)
-public class ServerLevelMixin {
+public abstract class ServerLevelMixin extends Level {
 
-    @WrapOperation(method="tickChunk", at=@At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;isThundering()Z"))
+    protected ServerLevelMixin(
+            final WritableLevelData levelData,
+            final ResourceKey<Level> dimension,
+            final RegistryAccess registryAccess,
+            final Holder<DimensionType> dimensionTypeRegistration,
+            final Supplier<ProfilerFiller> profiler,
+            final boolean isClientSide,
+            final boolean isDebug,
+            final long biomeZoomSeed,
+            final int maxChainedNeighborUpdates) {
+        super(levelData, dimension, registryAccess, dimensionTypeRegistration, profiler, isClientSide, isDebug, biomeZoomSeed, maxChainedNeighborUpdates);
+    }
+
+    @WrapOperation(method = "tickChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;isThundering()Z"))
     private boolean sable$preventLightningInPlot(final ServerLevel instance, final Operation<Boolean> original, @Local(argsOnly = true) final LevelChunk chunk) {
-        final SubLevelContainer plotContainer = SubLevelContainer.getContainer((ServerLevel) (Object) this);
-        assert plotContainer != null;
-
-        if (plotContainer.getPlot(chunk.getPos()) != null) {
+        final SubLevelContainer plotContainer = SubLevelContainer.getContainer(this);
+        if (plotContainer != null && plotContainer.inBounds(chunk.getPos())) {
             return false;
         }
         return original.call(instance);
     }
-
 }

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -208,6 +208,7 @@
     "sculk_vibrations.VibrationSystemListenerMixin",
     "sculk_vibrations.VibrationSystemTickerMixin",
     "sign_interaction.SignBlockEntityMixin",
+    "stop_lightning.ServerLevelMixin",
     "tracking_points.EntityMixin",
     "tracking_points.ServerPlayerMixin",
     "udp.ConnectionMixin",


### PR DESCRIPTION
Prevent lightning/skeleton traps from spawning inside the plot.
Since otherwise this just increases the density of lightning as you have more sublevels in an area, and these lightning strikes will just strike entities since they're the only real targets in the plot's lightning target checks.