### PR TITLE
Fix client hang during UDP bootstrap that prevents joining servers

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/udp/ConnectionMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/udp/ConnectionMixin.java
@@ -3,6 +3,7 @@ package dev.ryanhcode.sable.mixin.udp;
 import com.llamalad7.mixinextras.sugar.Local;
 import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.SableClient;
+import dev.ryanhcode.sable.SableConfig;
 import dev.ryanhcode.sable.mixinterface.udp.ConnectionExtension;
 import dev.ryanhcode.sable.network.udp.SableUDPPacket;
 import dev.ryanhcode.sable.network.udp.handler.SableUDPChannelHandlerClient;
@@ -24,6 +25,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
 
 @Mixin(Connection.class)
 public abstract class ConnectionMixin implements ConnectionExtension {
@@ -42,11 +44,14 @@ public abstract class ConnectionMixin implements ConnectionExtension {
         if (this.sable$udpChannel != null && this.sable$udpChannel.isOpen()) {
             this.sable$udpChannel = null;
 
+            Sable.LOGGER.debug("[sable-udp] closing UDP channel on disconnect, reason={}",
+                    disconnectionDetails != null ? disconnectionDetails.reason().getString() : "<no details>");
+
             channel.close().awaitUninterruptibly().addListener((x) -> {
                 if (x.isSuccess()) {
                     Sable.LOGGER.info("Closed UDP channel!");
                 } else {
-                    Sable.LOGGER.info("Failed to close UDP channel", x.cause());
+                    Sable.LOGGER.warn("Failed to close UDP channel", x.cause());
                 }
             });
         }
@@ -57,8 +62,17 @@ public abstract class ConnectionMixin implements ConnectionExtension {
         return this.sable$udpChannel;
     }
 
+    @Unique
+    private static final long SABLE$UDP_CONNECT_TIMEOUT_MS = 5_000L;
+
     @Inject(method = "connect", at = @At("TAIL"))
     private static void sable$connect(final InetSocketAddress inetSocketAddress, final boolean bl, final Connection connection, final CallbackInfoReturnable<ChannelFuture> cir) {
+        if (SableConfig.DISABLE_UDP_PIPELINE.get()) {
+            Sable.LOGGER.debug("[sable-udp] client UDP pipeline disabled via config; skipping bootstrap for {}", inetSocketAddress);
+            return;
+        }
+
+        final long startNs = System.nanoTime();
         final boolean useNativeTransport = SableClient.useNativeTransport();
 
         final Class<? extends Channel> channelClass;
@@ -72,35 +86,96 @@ public abstract class ConnectionMixin implements ConnectionExtension {
             eventLoopGroup = Connection.NETWORK_WORKER_GROUP.get();
         }
 
-        Sable.LOGGER.info("Starting remote client UDP channel future");
+        Sable.LOGGER.info("Starting remote client UDP channel future (remote={}, transport={})",
+                inetSocketAddress, channelClass.getSimpleName());
 
-        final ChannelFuture channelFuture = new Bootstrap().group(eventLoopGroup).handler(new ChannelInitializer<>() {
-                    @Override
-                    protected void initChannel(final Channel channel) {
-                        channel.config().setOption(ChannelOption.SO_KEEPALIVE, true);
-                        SableUDPPacket.configureSerialization(channel.pipeline(), PacketFlow.CLIENTBOUND, false, null);
-                        sable$setupChannel(channel, connection);
-                    }
-                })
-                .channel(channelClass)
-                .connect(inetSocketAddress.getAddress(), inetSocketAddress.getPort());
+        final ChannelFuture channelFuture;
+        try {
+            channelFuture = new Bootstrap().group(eventLoopGroup).handler(new ChannelInitializer<>() {
+                        @Override
+                        protected void initChannel(final Channel channel) {
+                            channel.config().setOption(ChannelOption.SO_KEEPALIVE, true);
+                            SableUDPPacket.configureSerialization(channel.pipeline(), PacketFlow.CLIENTBOUND, false, null);
+                            sable$setupChannel(channel, connection);
+                        }
+                    })
+                    .channel(channelClass)
+                    .connect(inetSocketAddress.getAddress(), inetSocketAddress.getPort());
+        } catch (final Throwable t) {
+            Sable.LOGGER.error("[sable-udp] Bootstrap.connect threw for {} (elapsedMs={}); continuing without UDP",
+                    inetSocketAddress, (System.nanoTime() - startNs) / 1_000_000L, t);
+            return;
+        }
 
-        channelFuture.syncUninterruptibly();
+        final boolean completed = channelFuture.awaitUninterruptibly(SABLE$UDP_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        final long elapsedMs = (System.nanoTime() - startNs) / 1_000_000L;
+
+        if (!completed) {
+            Sable.LOGGER.warn("[sable-udp] UDP connect did not complete within {}ms for remote={} (elapsedMs={}); cancelling future and falling back to TCP-only. This usually indicates the OS-level UDP connect() call is blocking - check antivirus/firewall outbound UDP rules.",
+                    SABLE$UDP_CONNECT_TIMEOUT_MS, inetSocketAddress, elapsedMs);
+            channelFuture.cancel(true);
+            channelFuture.addListener((ChannelFutureListener) f -> {
+                if (f.isCancelled()) {
+                    return;
+                }
+                if (f.cause() != null) {
+                    Sable.LOGGER.warn("[sable-udp] late UDP connect failure for {}: {}", inetSocketAddress, f.cause().toString());
+                } else if (f.isSuccess() && f.channel() != null) {
+                    Sable.LOGGER.debug("[sable-udp] late UDP connect success for {} after timeout; closing channel", inetSocketAddress);
+                    f.channel().close();
+                }
+            });
+            return;
+        }
+
+        if (!channelFuture.isSuccess()) {
+            Sable.LOGGER.warn("[sable-udp] UDP connect failed for remote={} (elapsedMs={}); falling back to TCP-only. cause={}",
+                    inetSocketAddress, elapsedMs, channelFuture.cause() != null ? channelFuture.cause().toString() : "<no cause>");
+            return;
+        }
+
+        Sable.LOGGER.debug("[sable-udp] UDP connect succeeded for remote={} (elapsedMs={})", inetSocketAddress, elapsedMs);
     }
 
     @Inject(method = "connectToLocalServer", at = @At("TAIL"))
     private static void sable$connectToLocalServer(final SocketAddress socketAddress, final CallbackInfoReturnable<Connection> cir, @Local final Connection connection) {
+        if (SableConfig.DISABLE_UDP_PIPELINE.get()) {
+            Sable.LOGGER.debug("[sable-udp] local UDP pipeline disabled via config; skipping bootstrap for {}", socketAddress);
+            return;
+        }
+
+        final long startNs = System.nanoTime();
         Sable.LOGGER.info("Starting local client UDP channel future");
 
-        final ChannelFuture channelFuture = new Bootstrap().group(Connection.LOCAL_WORKER_GROUP.get()).handler(new ChannelInitializer<>() {
-            @Override
-            protected void initChannel(final Channel channel) {
-                SableUDPPacket.configureInMemoryPipeline(channel.pipeline(), PacketFlow.CLIENTBOUND);
-                sable$setupChannel(channel, connection);
-            }
-        }).channel(LocalChannel.class).connect(socketAddress).syncUninterruptibly();
+        final ChannelFuture channelFuture;
+        try {
+            channelFuture = new Bootstrap().group(Connection.LOCAL_WORKER_GROUP.get()).handler(new ChannelInitializer<>() {
+                @Override
+                protected void initChannel(final Channel channel) {
+                    SableUDPPacket.configureInMemoryPipeline(channel.pipeline(), PacketFlow.CLIENTBOUND);
+                    sable$setupChannel(channel, connection);
+                }
+            }).channel(LocalChannel.class).connect(socketAddress);
+        } catch (final Throwable t) {
+            Sable.LOGGER.error("[sable-udp] local Bootstrap.connect threw for {} (elapsedMs={})",
+                    socketAddress, (System.nanoTime() - startNs) / 1_000_000L, t);
+            return;
+        }
 
-        channelFuture.syncUninterruptibly();
+        final boolean completed = channelFuture.awaitUninterruptibly(SABLE$UDP_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        final long elapsedMs = (System.nanoTime() - startNs) / 1_000_000L;
+        if (!completed) {
+            Sable.LOGGER.warn("[sable-udp] local UDP connect timed out after {}ms for {} (elapsedMs={}); cancelling",
+                    SABLE$UDP_CONNECT_TIMEOUT_MS, socketAddress, elapsedMs);
+            channelFuture.cancel(true);
+            return;
+        }
+        if (!channelFuture.isSuccess()) {
+            Sable.LOGGER.warn("[sable-udp] local UDP connect failed for {} (elapsedMs={}): {}",
+                    socketAddress, elapsedMs, channelFuture.cause() != null ? channelFuture.cause().toString() : "<no cause>");
+            return;
+        }
+        Sable.LOGGER.debug("[sable-udp] local UDP connect succeeded for {} (elapsedMs={})", socketAddress, elapsedMs);
     }
 
     @Unique

--- a/common/src/main/java/dev/ryanhcode/sable/network/packets/tcp/ClientboundSableUDPActivationPacket.java
+++ b/common/src/main/java/dev/ryanhcode/sable/network/packets/tcp/ClientboundSableUDPActivationPacket.java
@@ -43,7 +43,16 @@ public record ClientboundSableUDPActivationPacket(UUID uuid) implements SableTCP
         final ConnectionExtension connectionExtension = (ConnectionExtension) connection;
         final Channel channel = connectionExtension.sable$getUDPChannel();
 
-        final InetSocketAddress baseAddress = ((InetSocketAddress) connection.getRemoteAddress());
+        if (channel == null) {
+            Sable.LOGGER.warn("[sable-udp] Received UDP activation packet but no UDP channel is available on this connection; remaining on TCP-only");
+            return;
+        }
+
+        if (!(connection.getRemoteAddress() instanceof final InetSocketAddress baseAddress)) {
+            Sable.LOGGER.warn("[sable-udp] Received UDP activation packet but remote address is not an InetSocketAddress ({}); skipping UDP auth", connection.getRemoteAddress());
+            return;
+        }
+
         final InetSocketAddress remoteAddress = new InetSocketAddress(baseAddress.getAddress(), baseAddress.getPort());
 
         Sable.LOGGER.info("Received authentication request, sending response over UDP to {}", remoteAddress);
@@ -54,7 +63,12 @@ public record ClientboundSableUDPActivationPacket(UUID uuid) implements SableTCP
             final AddressedSableUDPPacket envelope = new AddressedSableUDPPacket(packet, remoteAddress);
             final ChannelFuture writeFuture = channel.writeAndFlush(envelope);
 
-            writeFuture.addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+            writeFuture.addListener((ChannelFutureListener) f -> {
+                if (!f.isSuccess()) {
+                    Sable.LOGGER.warn("[sable-udp] Failed to send UDP auth response to {}: {}",
+                            remoteAddress, f.cause() != null ? f.cause().toString() : "<no cause>");
+                }
+            });
         });
     }
 }

--- a/common/src/main/java/dev/ryanhcode/sable/network/udp/handler/SableUDPChannelHandlerClient.java
+++ b/common/src/main/java/dev/ryanhcode/sable/network/udp/handler/SableUDPChannelHandlerClient.java
@@ -23,13 +23,16 @@ public class SableUDPChannelHandlerClient extends SimpleChannelInboundHandler<Ad
     @Override
     public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) throws Exception {
         super.exceptionCaught(ctx, cause);
-        Sable.LOGGER.error("UDP channel exception caught", cause);
+        Sable.LOGGER.error("UDP channel exception caught (local={}, remote={})",
+                ctx.channel().localAddress(), ctx.channel().remoteAddress(), cause);
     }
 
     @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
         super.channelActive(ctx);
         Sable.LOGGER.info("Client UDP channel active");
+        Sable.LOGGER.debug("[sable-udp] channel id={}, local={}, remote={}",
+                ctx.channel().id(), ctx.channel().localAddress(), ctx.channel().remoteAddress());
 
         this.channel = ctx.channel();
         ((ConnectionExtension) this.connection).sable$setUDPChannel(this.channel);


### PR DESCRIPTION
## Problem

`ConnectionMixin.sable$connect` (and its local-server twin) opens a UDP channel alongside the Minecraft TCP one when the player connects. The bootstrap currently ends with:

```java
final ChannelFuture channelFuture = new Bootstrap()...
        .connect(inetSocketAddress.getAddress(), inetSocketAddress.getPort());

channelFuture.syncUninterruptibly();
```

That `syncUninterruptibly()` runs on the `Server Pinger` (multiplayer list refresh) and `Server Connector` (actual join) threads. Those are the same threads that drive the TCP handshake / config phase of the Minecraft login. As long as the netty UDP `connect()` future hasn't resolved, no TCP login can make progress.

On most hosts the UDP `connect()` returns within milliseconds (UDP "connect" is just an OS-level associate-with-remote-address â€” no packets fly). But the netty call goes through `NioDatagramChannel.doConnect()` â†’ `javaChannel().connect(remoteAddress)`, which on Windows can stall when a third party is interposed on the socket layer: Windows Filtering Platform callouts from antivirus, "secure DNS" / enterprise proxies, some VPN clients, or layered service providers doing UDP inspection. On the affected client in this repro, that stall lasted 20-30+ seconds; the server's read-timeout fired first and closed the TCP socket. From the user's perspective, the login screen sat on "Connectingâ€¦" and then bounced with a generic "Disconnected".

This is the same shape of failure surfaced (with different proximate causes) in #852, #850 (workaround: `attempt_udp_networking=false`), #1035 (closed as dup of #482), and #1080 (NPE that this PR also fixes).

## Repro

* Sable NeoForge 1.21.1-1.2.2, Synthetic Horizons modpack, MC 1.21.1 + NeoForge 21.1.233.
* One Windows 11 laptop on the LAN couldn't join a dedicated server (locally to `192.168.1.90:25565` or remotely to `47.38.244.85:25565`). Other machines on the same LAN with the same pack joined fine.
* Pinger thread eventually succeeded in bringing up its UDP channel (server appeared in the list), but the Server Connector's UDP bootstrap was the long one â€” long enough to push the server past its config-phase timeout.
* With the patch in place on the same machine, UDP bootstrap completes in 1 ms on the same network path, and the player joins. The "drowning in the spawn ocean" verification was, uh, vivid.

## Alternatives considered

I went through a few options before landing on this one. Recording them so reviewers can push back if they prefer a different shape.

1. **Tell users to set `disable_udp_pipeline=true` and call it done.** This is the documented workaround today and was suggested on #1080. It works, but (a) it silently downgrades every user to TCP-only sub-level data forever rather than only on machines where UDP genuinely can't be set up, (b) the flag only short-circuits the server-side `ServerConnectionListenerMixin` â€” `ConnectionMixin.sable$connect` ignored it, so users following the doc were still hitting the bootstrap on the client, and (c) it doesn't address the root cause (a blocking call on the login thread).

2. **Move the UDP bootstrap off the login thread entirely** (run the `Bootstrap.connect(...)` on the netty event loop and `setUDPChannel` from a listener). Cleaner long-term shape -- UDP bring-up becomes purely async, no timing coupling with TCP login at all. I didn't take this because it changes the lifecycle assumptions made by `ClientboundSableUDPActivationPacket.handle` (which today reads `sable$getUDPChannel()` synchronously, expecting connect() to be done by the time the server's activation packet arrives) and by anyone reading the field elsewhere. That's a bigger change with a wider blast radius for a backport-friendly fix, so I deferred it. Happy to do it as a follow-up if the maintainers prefer.

3. **Bounded `await` with a timeout, fall back to TCP-only on failure.** What this PR does. The synchronous shape is preserved (so existing assumptions about `sable$getUDPChannel()` after `Connection.connect` returns still hold for the success path), but a slow or stuck `connect()` no longer holds the login thread hostage. The timeout (5 s) is generous enough that healthy networks always succeed (success path observed at <1 ms on every machine I tested) and short enough that the server-side login window (which is also ~20-30 s before the read-timeout fires) is preserved.

4. **Make the timeout configurable.** Considered; rejected for now. A config knob is overkill when the practical range is "<1 s succeeds, otherwise something is broken and we want to fail fast". If a future deployment surfaces a legitimate need for a longer wait, promoting `SABLE$UDP_CONNECT_TIMEOUT_MS` to `SableConfig` is one line.

## What this PR does

* **`ConnectionMixin.sable$connect`**: replace `syncUninterruptibly()` with `awaitUninterruptibly(SABLE$UDP_CONNECT_TIMEOUT_MS, MILLISECONDS)` (5 s). On timeout: cancel the future, install a listener that logs the late outcome (and closes the channel if it eventually succeeds after we already gave up), return â€” letting TCP login proceed. On `!isSuccess()`: log the cause, return. Wrap the bootstrap construction itself in try/catch so an unchecked exception during bootstrap can't break the connect call either.
* **`ConnectionMixin.sable$connectToLocalServer`**: same treatment for `LocalChannel`. Less critical (local channels rarely stall) but the inconsistency was hard to justify keeping.
* **Honor `SableConfig.DISABLE_UDP_PIPELINE` on the client**: short-circuit both connect injects when the flag is set. Previously only `ServerConnectionListenerMixin` checked it, which made the documented workaround a half-measure.
* **`ClientboundSableUDPActivationPacket.handle`**: null-check `connectionExtension.sable$getUDPChannel()` before dereferencing â€” fixes the NPE in #1080 (`Cannot invoke 'io.netty.channel.Channel.eventLoop()' because 'channel' is null`). When the channel is null, log a WARN and return; the client stays on TCP-only and the server's auth state for that connection just stays in `AWAITING_AUTH` until the connection closes. Also pattern-match the `connection.getRemoteAddress()` cast instead of an unchecked one.
* **Logging cleanup**: the existing `Starting remote client UDP channel future` line now carries the remote address and transport class so logs from affected users are immediately actionable. All failure paths log at WARN with the cause. Routine breadcrumbs (config-disabled short-circuit, late-success-after-cancel, success path with timing) are demoted to DEBUG so unaffected users don't see any new chatter.

## Implications

### Success path
Byte-for-byte identical end-state -- the channel is set on the `ConnectionExtension`, `SableUDPChannelHandlerClient.channelActive` fires, `ClientboundSableUDPActivationPacket.handle` sees the channel and dispatches the auth response, server transitions `SableUDPAuthenticationState` to `AUTHENTICATED`. No timing changes when UDP comes up healthily (success observed at <1 ms across machines tested).

### Failure / timeout path (where this PR is doing the actual work)

The interesting question is "if UDP setup fails, what's broken for the player?" I traced the gameplay-affecting UDP call sites to answer that:

* `sendUDPPacket` has two production call sites in the codebase: `SubLevelTrackingSystem.java:367-397` (sub-level snapshot replication) and `SableCommand.java:58` (a debug echo command). The tracking system already has an **explicit, designed-in TCP fallback branch** keyed on `isConnectedTo(player)` â€” sub-level snapshots are sent as a `ClientboundBundlePacket(ClientboundSableSnapshotInfoDualPacket, ClientboundSableSnapshotDualPacket)` over TCP when UDP isn't authenticated. The packets are *Dual* (`SableUDPPacket, SableTCPPacket`) and the client decodes them identically off either transport; the only branch in `ClientSableInterpolationState.receiveSnapshot` on the receive mode is a debug-overlay string ("Networking through UDP/TCP"). The interpolation math, the snapshot buffer, and the rendered sub-level position are all identical.
* `isConnectedTo(player)` returns `false` cleanly in our failure path (`udpAuthStates` entry stays in `AWAITING_AUTH` because the client never replies with `SableUDPAuthenticationPacket`).
* `SableUDPServer.sendPings()` skips players that aren't `AUTHENTICATED`, so a fallback-to-TCP player generates no UDP keepalive traffic and is never bounced by the missed-pings logic.

So the practical effect of our timeout firing is: **the player joins, sub-levels work normally, the only observable difference is the F3 debug overlay reports "Networking through TCP"** (or "UNKNOWN" until the first snapshot arrives). The one real degradation is that under a **lossy** network, sub-level snapshots over TCP can show jitter from head-of-line blocking that UDP wouldn't have â€” but the failure mode that triggers this PR is at the OS socket layer, not on-wire packet loss, so affected users typically have clean networks and see no visible difference.

### Other behavioral notes

* **`disable_udp_pipeline` now means what it says** on the client â€” no UDP bootstrap, no UDP channel, no log lines. Previously the flag only short-circuited the server bootstrap, so a user setting it client-side (as #1080 recommends as a workaround) was still hitting the buggy bootstrap. This is a small behavior change for anyone relying on the side-effect that the client kept opening a UDP channel; I don't think such users exist, but worth calling out.
* **Stale auth-state entries**: in the timeout path, the server's `udpAuthStates` map keeps an `AWAITING_AUTH` entry for the connection whose client never replied. The map is a `WeakHashMap` keyed on `Connection` and entries are also pruned in `SableUDPServer.sendPings()` when `!connection.isConnected()`, so it cleans up on disconnect. No leak; called out for completeness.
* **No protocol change**, no packet format change, no jarjar change. Drop-in compatible across mixed 1.2.2 / patched-1.2.2 deployments â€” server-patched + client-unpatched (or vice versa) negotiates UDP exactly the same way it does today.
* **No new dependencies**. One `@Unique` field added: `SABLE$UDP_CONNECT_TIMEOUT_MS` (mixin-safe naming).

## AI assistance

This change was developed with the assistance of an AI coding assistant (Claude). I read every line, built the jar locally against `mc1.21.1-1.2.2-neoforge`, dropped it into the affected modpack instance, reproduced the original join failure on the affected machine, watched it succeed with the fix, and read the resulting logs to confirm the WARN/DEBUG split is what I want a future bug report to contain. I'm submitting this as my own contribution under the CONTRIBUTING.md terms.

## Related issues

* #1080 -- Client-side NPE in `ClientboundSableUDPActivationPacket` (fixed directly by the channel null guard)
* #852 -- Not able to join the server (consistent with this PR's repro for the subset of reports where the proximate cause is a slow OS-level UDP `connect()`)
* #850 -- Severe desync from server when UDP is enabled (different root cause; not addressed here)
* #1035 / #482 -- Server-side crash without disabling UDP pipeline (server-side; not addressed here)
