### PR TITLE
Add Waystones compatibility (teleport + distance on sub-levels)

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/ActiveSableCompanion.java
+++ b/common/src/main/java/dev/ryanhcode/sable/ActiveSableCompanion.java
@@ -217,11 +217,7 @@ public class ActiveSableCompanion implements SableCompanion {
     }
 
     /**
-     * Resolves the last-known pose of a held (unloaded) sub-level whose reserved plot contains the
-     * given world position, so distance/cost queries can project an unloaded sub-level's coordinate
-     * to its approximate world location without loading it back in. Returns {@code null} when the
-     * position is not inside any reserved plot (e.g. ordinary world positions), in which case the
-     * caller leaves the coordinate untouched.
+     * @return the last-known pose of the held sub-level whose reserved plot contains the position, or {@code null} if none
      */
     private @Nullable Pose3dc lastKnownContainingPose(final Level level, final double blockX, final double blockZ) {
         final SubLevelContainer container = SubLevelContainer.getContainer(level);

--- a/common/src/main/java/dev/ryanhcode/sable/ActiveSableCompanion.java
+++ b/common/src/main/java/dev/ryanhcode/sable/ActiveSableCompanion.java
@@ -171,7 +171,13 @@ public class ActiveSableCompanion implements SableCompanion {
     public Vector3d projectOutOfSubLevel(final Level level, final Vector3dc pos, final Vector3d dest) {
         final SubLevel subLevel = this.getContaining(level, pos);
 
-        if (subLevel == null) return dest.set(pos);
+        if (subLevel == null) {
+            final Pose3dc lastPose = this.lastKnownContainingPose(level, pos.x(), pos.z());
+            if (lastPose != null) {
+                return lastPose.transformPosition(pos, dest);
+            }
+            return dest.set(pos);
+        }
 
         final Pose3dc pose;
         if (level instanceof final LevelPoseProviderExtension extension) {
@@ -192,7 +198,13 @@ public class ActiveSableCompanion implements SableCompanion {
     public Vec3 projectOutOfSubLevel(final Level level, final Position pos) {
         final SubLevel subLevel = this.getContaining(level, pos);
 
-        if (subLevel == null) return pos instanceof final Vec3 vec ? vec : new Vec3(pos.x(), pos.y(), pos.z());
+        if (subLevel == null) {
+            final Pose3dc lastPose = this.lastKnownContainingPose(level, pos.x(), pos.z());
+            if (lastPose != null) {
+                return JOMLConversion.toMojang(lastPose.transformPosition(JOMLConversion.toJOML(pos)));
+            }
+            return pos instanceof final Vec3 vec ? vec : new Vec3(pos.x(), pos.y(), pos.z());
+        }
 
         final Pose3dc pose;
         if (level instanceof final LevelPoseProviderExtension extension) {
@@ -202,6 +214,23 @@ public class ActiveSableCompanion implements SableCompanion {
         }
 
         return JOMLConversion.toMojang(pose.transformPosition(JOMLConversion.toJOML(pos)));
+    }
+
+    /**
+     * Resolves the last-known pose of a held (unloaded) sub-level whose reserved plot contains the
+     * given world position, so distance/cost queries can project an unloaded sub-level's coordinate
+     * to its approximate world location without loading it back in. Returns {@code null} when the
+     * position is not inside any reserved plot (e.g. ordinary world positions), in which case the
+     * caller leaves the coordinate untouched.
+     */
+    private @Nullable Pose3dc lastKnownContainingPose(final Level level, final double blockX, final double blockZ) {
+        final SubLevelContainer container = SubLevelContainer.getContainer(level);
+        if (container == null) {
+            return null;
+        }
+        final int chunkX = Mth.floor(blockX) >> SectionPos.SECTION_BITS;
+        final int chunkZ = Mth.floor(blockZ) >> SectionPos.SECTION_BITS;
+        return container.getLastKnownPose(chunkX, chunkZ);
     }
 
     @Override

--- a/common/src/main/java/dev/ryanhcode/sable/api/sublevel/SubLevelContainer.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/sublevel/SubLevelContainer.java
@@ -59,16 +59,11 @@ public abstract class SubLevelContainer {
      */
     private final BitSet occupancy;
     /**
-     * The last-known pose of each plot, indexed identically to {@link #subLevels}. Set while a
-     * sub-level is allocated and refreshed when it unloads, so that distance and cost queries can
-     * resolve a held (unloaded) sub-level's approximate world position without loading it back in.
-     * {@code null} for unoccupied plots.
+     * The last-known pose of each plot, kept while held so unloaded sub-levels can be located. {@code null} if unoccupied.
      */
     private final Pose3d[] lastKnownPoses;
     /**
-     * The UUID of the sub-level occupying each plot, indexed identically to {@link #subLevels}. Kept
-     * for held (unloaded) plots so callers can identify - and freeze a player to - a sub-level
-     * without loading it back in. {@code null} for unoccupied plots.
+     * The sub-level UUID of each plot, kept while held. {@code null} if unoccupied.
      */
     private final UUID[] lastKnownUuids;
     /**
@@ -507,8 +502,7 @@ public abstract class SubLevelContainer {
             this.lastKnownPoses[index] = null;
             this.lastKnownUuids[index] = null;
         } else {
-            // Still held, just unloaded: remember where it was so distance/cost queries can resolve
-            // its approximate world position without loading the sub-level back in.
+            // Held, not removed: remember its pose so it can be located while unloaded.
             this.lastKnownPoses[index] = new Pose3d(subLevel.logicalPose());
         }
 
@@ -518,12 +512,8 @@ public abstract class SubLevelContainer {
     }
 
     /**
-     * Returns the last-known pose of the (possibly unloaded) sub-level whose plot contains the given
-     * global chunk position. While the sub-level is loaded this is its allocation/last-unload pose,
-     * which is stale - callers that need the live pose should use {@link #getContaining} first and
-     * fall back to this only when no loaded sub-level is present.
-     *
-     * @return the last-known pose, or {@code null} if no plot is reserved at that position
+     * @return the last-known pose of the (possibly unloaded) sub-level at the given chunk, or {@code null} if none.
+     * Stale while loaded; prefer {@link #getContaining} when a live pose is required
      */
     public @Nullable Pose3d getLastKnownPose(final int chunkX, final int chunkZ) {
         final int plotX = (chunkX >> this.logPlotSize) - this.originX;
@@ -536,10 +526,7 @@ public abstract class SubLevelContainer {
     }
 
     /**
-     * Returns the UUID of the (possibly unloaded) sub-level whose plot contains the given global
-     * chunk position, so a held sub-level can be identified - and frozen to - without loading it.
-     *
-     * @return the sub-level UUID, or {@code null} if no plot is reserved at that position
+     * @return the UUID of the (possibly unloaded) sub-level at the given chunk, or {@code null} if none
      */
     public @Nullable UUID getLastKnownUuid(final int chunkX, final int chunkZ) {
         final int plotX = (chunkX >> this.logPlotSize) - this.originX;
@@ -552,7 +539,7 @@ public abstract class SubLevelContainer {
     }
 
     /**
-     * @return the persisted sub-level UUID for the plot at the given index, or {@code null} if none.
+     * @return the sub-level UUID stored for the plot index, or {@code null} if none
      */
     @ApiStatus.Internal
     public @Nullable UUID getLastKnownUuid(final int index) {
@@ -574,8 +561,7 @@ public abstract class SubLevelContainer {
     }
 
     /**
-     * @return the pose to persist for the plot at the given index: the live pose when the sub-level
-     * is currently loaded, otherwise the last-known pose captured when it was unloaded.
+     * @return the live pose if the plot's sub-level is loaded, otherwise its last-known pose
      */
     @ApiStatus.Internal
     public @Nullable Pose3d getPersistablePose(final int index) {

--- a/common/src/main/java/dev/ryanhcode/sable/api/sublevel/SubLevelContainer.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/sublevel/SubLevelContainer.java
@@ -66,6 +66,12 @@ public abstract class SubLevelContainer {
      */
     private final Pose3d[] lastKnownPoses;
     /**
+     * The UUID of the sub-level occupying each plot, indexed identically to {@link #subLevels}. Kept
+     * for held (unloaded) plots so callers can identify - and freeze a player to - a sub-level
+     * without loading it back in. {@code null} for unoccupied plots.
+     */
+    private final UUID[] lastKnownUuids;
+    /**
      * All observers/listeners for the plotgrid
      */
     private final List<SubLevelObserver> observers = new ObjectArrayList<>();
@@ -143,6 +149,7 @@ public abstract class SubLevelContainer {
         this.subLevels = new SubLevel[(1 << logSideLength) * (1 << logSideLength)];
         this.occupancy = new BitSet(this.subLevels.length);
         this.lastKnownPoses = new Pose3d[this.subLevels.length];
+        this.lastKnownUuids = new UUID[this.subLevels.length];
     }
 
     /**
@@ -270,6 +277,7 @@ public abstract class SubLevelContainer {
         this.subLevels[index] = subLevel;
         this.getOccupancy().set(index);
         this.lastKnownPoses[index] = new Pose3d(pose);
+        this.lastKnownUuids[index] = uuid;
         this.allSubLevels.add(subLevel);
         this.subLevelsByUUID.put(subLevel.getUniqueId(), subLevel);
         this.observers.forEach(observer -> observer.onSubLevelAdded(subLevel));
@@ -497,6 +505,7 @@ public abstract class SubLevelContainer {
         if (reason == SubLevelRemovalReason.REMOVED) {
             this.getOccupancy().clear(index);
             this.lastKnownPoses[index] = null;
+            this.lastKnownUuids[index] = null;
         } else {
             // Still held, just unloaded: remember where it was so distance/cost queries can resolve
             // its approximate world position without loading the sub-level back in.
@@ -524,6 +533,44 @@ public abstract class SubLevelContainer {
             return null;
         }
         return this.lastKnownPoses[this.getIndex(plotX, plotZ)];
+    }
+
+    /**
+     * Returns the UUID of the (possibly unloaded) sub-level whose plot contains the given global
+     * chunk position, so a held sub-level can be identified - and frozen to - without loading it.
+     *
+     * @return the sub-level UUID, or {@code null} if no plot is reserved at that position
+     */
+    public @Nullable UUID getLastKnownUuid(final int chunkX, final int chunkZ) {
+        final int plotX = (chunkX >> this.logPlotSize) - this.originX;
+        final int plotZ = (chunkZ >> this.logPlotSize) - this.originZ;
+        final int sideLength = 1 << this.logSideLength;
+        if (plotX < 0 || plotX >= sideLength || plotZ < 0 || plotZ >= sideLength) {
+            return null;
+        }
+        return this.lastKnownUuids[this.getIndex(plotX, plotZ)];
+    }
+
+    /**
+     * @return the persisted sub-level UUID for the plot at the given index, or {@code null} if none.
+     */
+    @ApiStatus.Internal
+    public @Nullable UUID getLastKnownUuid(final int index) {
+        if (index < 0 || index >= this.lastKnownUuids.length) {
+            return null;
+        }
+        return this.lastKnownUuids[index];
+    }
+
+    /**
+     * Restores a persisted sub-level UUID for the plot at the given index.
+     */
+    @ApiStatus.Internal
+    public void setLastKnownUuid(final int index, final UUID uuid) {
+        if (index < 0 || index >= this.lastKnownUuids.length) {
+            return;
+        }
+        this.lastKnownUuids[index] = uuid;
     }
 
     /**

--- a/common/src/main/java/dev/ryanhcode/sable/api/sublevel/SubLevelContainer.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/sublevel/SubLevelContainer.java
@@ -59,6 +59,13 @@ public abstract class SubLevelContainer {
      */
     private final BitSet occupancy;
     /**
+     * The last-known pose of each plot, indexed identically to {@link #subLevels}. Set while a
+     * sub-level is allocated and refreshed when it unloads, so that distance and cost queries can
+     * resolve a held (unloaded) sub-level's approximate world position without loading it back in.
+     * {@code null} for unoccupied plots.
+     */
+    private final Pose3d[] lastKnownPoses;
+    /**
      * All observers/listeners for the plotgrid
      */
     private final List<SubLevelObserver> observers = new ObjectArrayList<>();
@@ -135,6 +142,7 @@ public abstract class SubLevelContainer {
         this.originZ = originZ;
         this.subLevels = new SubLevel[(1 << logSideLength) * (1 << logSideLength)];
         this.occupancy = new BitSet(this.subLevels.length);
+        this.lastKnownPoses = new Pose3d[this.subLevels.length];
     }
 
     /**
@@ -261,6 +269,7 @@ public abstract class SubLevelContainer {
         final int index = this.getIndex(x, z);
         this.subLevels[index] = subLevel;
         this.getOccupancy().set(index);
+        this.lastKnownPoses[index] = new Pose3d(pose);
         this.allSubLevels.add(subLevel);
         this.subLevelsByUUID.put(subLevel.getUniqueId(), subLevel);
         this.observers.forEach(observer -> observer.onSubLevelAdded(subLevel));
@@ -487,7 +496,61 @@ public abstract class SubLevelContainer {
 
         if (reason == SubLevelRemovalReason.REMOVED) {
             this.getOccupancy().clear(index);
+            this.lastKnownPoses[index] = null;
+        } else {
+            // Still held, just unloaded: remember where it was so distance/cost queries can resolve
+            // its approximate world position without loading the sub-level back in.
+            this.lastKnownPoses[index] = new Pose3d(subLevel.logicalPose());
         }
+
+        if (this.level instanceof final ServerLevel serverLevel) {
+            SubLevelOccupancySavedData.getOrLoad(serverLevel).setDirty();
+        }
+    }
+
+    /**
+     * Returns the last-known pose of the (possibly unloaded) sub-level whose plot contains the given
+     * global chunk position. While the sub-level is loaded this is its allocation/last-unload pose,
+     * which is stale - callers that need the live pose should use {@link #getContaining} first and
+     * fall back to this only when no loaded sub-level is present.
+     *
+     * @return the last-known pose, or {@code null} if no plot is reserved at that position
+     */
+    public @Nullable Pose3d getLastKnownPose(final int chunkX, final int chunkZ) {
+        final int plotX = (chunkX >> this.logPlotSize) - this.originX;
+        final int plotZ = (chunkZ >> this.logPlotSize) - this.originZ;
+        final int sideLength = 1 << this.logSideLength;
+        if (plotX < 0 || plotX >= sideLength || plotZ < 0 || plotZ >= sideLength) {
+            return null;
+        }
+        return this.lastKnownPoses[this.getIndex(plotX, plotZ)];
+    }
+
+    /**
+     * @return the pose to persist for the plot at the given index: the live pose when the sub-level
+     * is currently loaded, otherwise the last-known pose captured when it was unloaded.
+     */
+    @ApiStatus.Internal
+    public @Nullable Pose3d getPersistablePose(final int index) {
+        if (index < 0 || index >= this.subLevels.length) {
+            return null;
+        }
+        final SubLevel loaded = this.subLevels[index];
+        if (loaded != null) {
+            return new Pose3d(loaded.logicalPose());
+        }
+        return this.lastKnownPoses[index];
+    }
+
+    /**
+     * Restores a persisted last-known pose for the plot at the given index.
+     */
+    @ApiStatus.Internal
+    public void setLastKnownPose(final int index, final Pose3d pose) {
+        if (index < 0 || index >= this.lastKnownPoses.length) {
+            return;
+        }
+        this.lastKnownPoses[index] = pose;
     }
 
     /**

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneButtonMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneButtonMixin.java
@@ -17,20 +17,14 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 /**
- * Hides the misleading distance for a waystone whose sub-level isn't loaded on this client.
- *
- * <p>A waystone on a sub-level stores the far-away plot-yard coordinate. While the contraption is
- * loaded, Sable's {@code Entity#distanceToSqr} overwrite projects it to the real location and the
- * distance is accurate. While it is unloaded here the client has no pose to project against, so the
- * distance would render as a meaningless ~20,000 km. The client can't recover the real distance
- * without the server streaming last-known poses, so instead we omit the distance entirely - the same
- * thing Waystones already does for cross-dimension waystones.
+ * Hides the distance for a waystone whose sub-level isn't loaded on this client. Its stored plot-yard
+ * coordinate can't be projected without a pose here, so the distance would show a meaningless
+ * ~20,000 km; omit it instead, as Waystones already does for cross-dimension waystones.
  */
 @Mixin(targets = "net.blay09.mods.waystones.client.gui.widget.WaystoneButton", remap = false)
 public abstract class WaystoneButtonMixin {
 
-    // `player` is statically a LocalPlayer at the call site, so the receiver parameter must be typed
-    // as LocalPlayer (MixinExtras requires the exact owner type, not a supertype).
+    // Receiver must be LocalPlayer (its static type at the call site); WrapOperation needs the exact owner.
     @WrapOperation(method = "renderWidget", at = @At(value = "INVOKE", target = "distanceToSqr(Lnet/minecraft/world/phys/Vec3;)D"))
     private double sable$detectUnloadedSubLevel(final LocalPlayer player, final Vec3 waystonePos, final Operation<Double> original, @Share("sableUnknownDistance") final LocalBooleanRef unknown) {
         unknown.set(sable$isOnUnloadedSubLevel(player.level(), waystonePos));
@@ -47,12 +41,11 @@ public abstract class WaystoneButtonMixin {
 
     @Unique
     private static boolean sable$isOnUnloadedSubLevel(final Level level, final Vec3 pos) {
-        // Loaded here: the projected distance is accurate, leave it alone.
+        // Loaded here: the projected distance is accurate.
         if (Sable.HELPER.getContaining(level, pos.x, pos.z) != null) {
             return false;
         }
-        // Otherwise, only treat it as unknown when the position is actually a reserved plot-yard
-        // coordinate - a genuinely far-away waystone keeps its real (large) distance.
+        // Only unknown when it's a plot-yard coordinate; a genuinely far waystone keeps its real distance.
         final SubLevelContainer container = SubLevelContainer.getContainer(level);
         return container != null && container.inBounds(BlockPos.containing(pos));
     }

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneButtonMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneButtonMixin.java
@@ -8,8 +8,8 @@ import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
@@ -29,10 +29,10 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(targets = "net.blay09.mods.waystones.client.gui.widget.WaystoneButton", remap = false)
 public abstract class WaystoneButtonMixin {
 
-    // Owner is intentionally omitted: `player` is statically a LocalPlayer here, so the call's owner
-    // is not Entity. An ownerless target matches the inherited distanceToSqr regardless.
+    // `player` is statically a LocalPlayer at the call site, so the receiver parameter must be typed
+    // as LocalPlayer (MixinExtras requires the exact owner type, not a supertype).
     @WrapOperation(method = "renderWidget", at = @At(value = "INVOKE", target = "distanceToSqr(Lnet/minecraft/world/phys/Vec3;)D"))
-    private double sable$detectUnloadedSubLevel(final Entity player, final Vec3 waystonePos, final Operation<Double> original, @Share("sableUnknownDistance") final LocalBooleanRef unknown) {
+    private double sable$detectUnloadedSubLevel(final LocalPlayer player, final Vec3 waystonePos, final Operation<Double> original, @Share("sableUnknownDistance") final LocalBooleanRef unknown) {
         unknown.set(sable$isOnUnloadedSubLevel(player.level(), waystonePos));
         return original.call(player, waystonePos);
     }

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneButtonMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneButtonMixin.java
@@ -1,0 +1,59 @@
+package dev.ryanhcode.sable.mixin.compatibility.waystones;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
+import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Hides the misleading distance for a waystone whose sub-level isn't loaded on this client.
+ *
+ * <p>A waystone on a sub-level stores the far-away plot-yard coordinate. While the contraption is
+ * loaded, Sable's {@code Entity#distanceToSqr} overwrite projects it to the real location and the
+ * distance is accurate. While it is unloaded here the client has no pose to project against, so the
+ * distance would render as a meaningless ~20,000 km. The client can't recover the real distance
+ * without the server streaming last-known poses, so instead we omit the distance entirely - the same
+ * thing Waystones already does for cross-dimension waystones.
+ */
+@Mixin(targets = "net.blay09.mods.waystones.client.gui.widget.WaystoneButton", remap = false)
+public abstract class WaystoneButtonMixin {
+
+    // Owner is intentionally omitted: `player` is statically a LocalPlayer here, so the call's owner
+    // is not Entity. An ownerless target matches the inherited distanceToSqr regardless.
+    @WrapOperation(method = "renderWidget", at = @At(value = "INVOKE", target = "distanceToSqr(Lnet/minecraft/world/phys/Vec3;)D"))
+    private double sable$detectUnloadedSubLevel(final Entity player, final Vec3 waystonePos, final Operation<Double> original, @Share("sableUnknownDistance") final LocalBooleanRef unknown) {
+        unknown.set(sable$isOnUnloadedSubLevel(player.level(), waystonePos));
+        return original.call(player, waystonePos);
+    }
+
+    @WrapOperation(method = "renderWidget", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;drawString(Lnet/minecraft/client/gui/Font;Ljava/lang/String;III)I"))
+    private int sable$hideUnloadedSubLevelDistance(final GuiGraphics graphics, final Font font, final String text, final int x, final int y, final int color, final Operation<Integer> original, @Share("sableUnknownDistance") final LocalBooleanRef unknown) {
+        if (unknown.get()) {
+            return 0;
+        }
+        return original.call(graphics, font, text, x, y, color);
+    }
+
+    @Unique
+    private static boolean sable$isOnUnloadedSubLevel(final Level level, final Vec3 pos) {
+        // Loaded here: the projected distance is accurate, leave it alone.
+        if (Sable.HELPER.getContaining(level, pos.x, pos.z) != null) {
+            return false;
+        }
+        // Otherwise, only treat it as unknown when the position is actually a reserved plot-yard
+        // coordinate - a genuinely far-away waystone keeps its real (large) distance.
+        final SubLevelContainer container = SubLevelContainer.getContainer(level);
+        return container != null && container.inBounds(BlockPos.containing(pos));
+    }
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneImplMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneImplMixin.java
@@ -1,0 +1,46 @@
+package dev.ryanhcode.sable.mixin.compatibility.waystones;
+
+import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.server.level.ServerLevel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Keeps a waystone on an unloaded sub-level valid as a teleport target.
+ *
+ * <p>{@code WaystoneImpl#isValidInLevel} checks {@code level.getBlockState(pos)} at the stored
+ * position, which for a waystone on an assembled sub-level is the plot-yard coordinate. While the
+ * contraption is unloaded its block isn't in the world, so the check fails and Waystones refuses with
+ * "currently being moved or has gone missing". If the position belongs to a reserved-but-unloaded
+ * sub-level plot, treat the waystone as valid - the warp re-activates the sub-level and the player is
+ * frozen onto it (see {@link WaystoneTeleportManagerMixin}).
+ */
+@Mixin(targets = "net.blay09.mods.waystones.core.WaystoneImpl", remap = false)
+public abstract class WaystoneImplMixin {
+
+    @Shadow
+    private BlockPos pos;
+
+    @Inject(method = "isValidInLevel", at = @At("HEAD"), cancellable = true)
+    private void sable$validOnHeldSubLevel(final ServerLevel level, final CallbackInfoReturnable<Boolean> cir) {
+        final SubLevelContainer container = SubLevelContainer.getContainer(level);
+        if (container == null) {
+            return;
+        }
+
+        final int chunkX = this.pos.getX() >> SectionPos.SECTION_BITS;
+        final int chunkZ = this.pos.getZ() >> SectionPos.SECTION_BITS;
+
+        // Reserved plot with no loaded sub-level == the waystone is on a held (unloaded) contraption.
+        // When loaded, fall through to the vanilla block check.
+        if (container.getLastKnownPose(chunkX, chunkZ) != null && Sable.HELPER.getContaining(level, chunkX, chunkZ) == null) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneImplMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneImplMixin.java
@@ -12,14 +12,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
- * Keeps a waystone on an unloaded sub-level valid as a teleport target.
- *
- * <p>{@code WaystoneImpl#isValidInLevel} checks {@code level.getBlockState(pos)} at the stored
- * position, which for a waystone on an assembled sub-level is the plot-yard coordinate. While the
- * contraption is unloaded its block isn't in the world, so the check fails and Waystones refuses with
- * "currently being moved or has gone missing". If the position belongs to a reserved-but-unloaded
- * sub-level plot, treat the waystone as valid - the warp re-activates the sub-level and the player is
- * frozen onto it (see {@link WaystoneTeleportManagerMixin}).
+ * Keeps a waystone on a held (unloaded) sub-level valid. {@code isValidInLevel} checks the block at
+ * the stored plot-yard position, which is empty while the contraption is unloaded; treat a
+ * reserved-but-unloaded sub-level plot as valid so the warp ({@link WaystoneTeleportManagerMixin})
+ * can re-activate it.
  */
 @Mixin(targets = "net.blay09.mods.waystones.core.WaystoneImpl", remap = false)
 public abstract class WaystoneImplMixin {
@@ -37,8 +33,7 @@ public abstract class WaystoneImplMixin {
         final int chunkX = this.pos.getX() >> SectionPos.SECTION_BITS;
         final int chunkZ = this.pos.getZ() >> SectionPos.SECTION_BITS;
 
-        // Reserved plot with no loaded sub-level == the waystone is on a held (unloaded) contraption.
-        // When loaded, fall through to the vanilla block check.
+        // Reserved plot, no loaded sub-level = held contraption; when loaded, let the vanilla block check run.
         if (container.getLastKnownPose(chunkX, chunkZ) != null && Sable.HELPER.getContaining(level, chunkX, chunkZ) == null) {
             cir.setReturnValue(true);
         }

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneTeleportManagerMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneTeleportManagerMixin.java
@@ -1,0 +1,41 @@
+package dev.ryanhcode.sable.mixin.compatibility.waystones;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import dev.ryanhcode.sable.Sable;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+/**
+ * Waystones stores a waystone's location as the raw block position of its block entity. For a waystone
+ * placed on an assembled Sable sub-level (e.g. an aircraft) that position is the hidden plot-yard
+ * coordinate (~20.48M blocks out), not the contraption's rendered location.
+ *
+ * <p>Sable already projects {@link net.minecraft.server.level.ServerPlayer#teleportTo} out of the
+ * sub-level, but Waystones' same-dimension warp path teleports via
+ * {@code connection.teleport(...)} directly, bypassing that projection. The player is dropped into the
+ * plot-yard, which desyncs the sub-level stream ("Received a sub-level movement packet for a
+ * non-existent sub-level") and freezes the server thread.
+ *
+ * <p>Project the teleport target out of the sub-level before the entity is moved. This affects only
+ * the entity placement (the warp-plate / modifier block-entity lookups still use the original plot
+ * position via {@code destination.location()}).
+ * {@link dev.ryanhcode.sable.api.SubLevelHelper#projectOutOfSubLevel} is a no-op for positions that
+ * are not inside a sub-level, so this is safe for ordinary warps and idempotent with the
+ * cross-dimension {@code teleportTo} path that Sable already handles.
+ */
+@Mixin(targets = "net.blay09.mods.waystones.core.WaystoneTeleportManager", remap = false)
+public class WaystoneTeleportManagerMixin {
+
+    @ModifyVariable(
+            method = "teleportEntity(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/core/Direction;)Lnet/minecraft/world/entity/Entity;",
+            at = @At("HEAD"),
+            argsOnly = true,
+            index = 2
+    )
+    private static Vec3 sable$projectTeleportTargetOutOfSubLevel(final Vec3 targetPos3d, @Local(argsOnly = true) final ServerLevel targetWorld) {
+        return Sable.HELPER.projectOutOfSubLevel(targetWorld, targetPos3d);
+    }
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneTeleportManagerMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneTeleportManagerMixin.java
@@ -27,24 +27,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.UUID;
 
 /**
- * Lets Waystones teleport onto Sable sub-levels (e.g. an aircraft).
- *
- * <p>A waystone placed on an assembled sub-level is stored at the hidden plot-yard coordinate. Two
- * things need to happen for a warp onto it to work:
- *
- * <ul>
- *   <li>The teleport target is projected out of the sub-level to the contraption's real (or, while
- *       unloaded, last-known) world position. Waystones' same-dimension warp uses
- *       {@code connection.teleport(...)} directly, bypassing Sable's {@code ServerPlayer#teleportTo}
- *       projection, so without this the player is dropped into the plot-yard and the server freezes.
- *   <li>If the contraption is currently unloaded, the player is frozen to the sub-level after the
- *       teleport. Teleporting to the last-known position re-activates the held sub-level (its holding
- *       chunk is keyed by that world position); the freeze then places the player precisely on the
- *       deck once it is live - the same mechanism Sable uses for bed respawns.
- * </ul>
- *
- * {@link dev.ryanhcode.sable.api.SubLevelHelper#projectOutOfSubLevel} is a no-op for positions that
- * are not inside a sub-level, so ordinary warps are unaffected.
+ * Lets Waystones warp onto sub-levels. A waystone on a sub-level is stored at its plot-yard
+ * coordinate, so the target is projected out to the contraption's real (or last-known) position -
+ * Waystones' same-dimension warp uses {@code connection.teleport} directly and would otherwise drop
+ * the player into the plot-yard. If the contraption is unloaded, the player is frozen to it after the
+ * teleport so they land on the deck once it re-activates, as bed respawns do.
  */
 @Mixin(targets = "net.blay09.mods.waystones.core.WaystoneTeleportManager", remap = false)
 public class WaystoneTeleportManagerMixin {
@@ -53,8 +40,7 @@ public class WaystoneTeleportManagerMixin {
 
     @ModifyVariable(method = TELEPORT_ENTITY, at = @At("HEAD"), argsOnly = true, index = 2)
     private static Vec3 sable$projectTeleportTarget(final Vec3 targetPos3d, @Local(argsOnly = true) final ServerLevel targetWorld, @Share("sableHeldFreeze") final LocalRef<Pair<UUID, Vector3d>> freezeRef) {
-        // If the waystone is on a currently-unloaded sub-level, remember which sub-level (and the
-        // local anchor) so the player can be frozen to it after the teleport.
+        // On an unloaded sub-level, remember it (and the local anchor) to freeze the player afterwards.
         final UUID heldUuid = sable$heldSubLevelUuid(targetWorld, targetPos3d);
         if (heldUuid != null) {
             freezeRef.set(Pair.of(heldUuid, new Vector3d(targetPos3d.x, targetPos3d.y, targetPos3d.z)));
@@ -77,9 +63,7 @@ public class WaystoneTeleportManagerMixin {
     }
 
     /**
-     * @return the UUID of the held (unloaded) sub-level whose plot contains the given target, or
-     * {@code null} if the target is in open world or on an already-loaded sub-level (in which case the
-     * ordinary teleport plus entity-sticking is enough).
+     * @return the UUID of the held (unloaded) sub-level at the target, or {@code null} if it is open world or already loaded
      */
     private static @Nullable UUID sable$heldSubLevelUuid(final ServerLevel level, final Vec3 pos) {
         if (Sable.HELPER.getContaining(level, pos.x, pos.z) != null) {

--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneTeleportManagerMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/waystones/WaystoneTeleportManagerMixin.java
@@ -1,41 +1,96 @@
 package dev.ryanhcode.sable.mixin.compatibility.waystones;
 
 import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
+import dev.ryanhcode.sable.mixinterface.player_freezing.PlayerFreezeExtension;
+import dev.ryanhcode.sable.network.packets.tcp.ClientboundFreezePlayerPacket;
+import it.unimi.dsi.fastutil.Pair;
+import net.minecraft.core.Direction;
+import net.minecraft.core.SectionPos;
+import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3d;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.UUID;
 
 /**
- * Waystones stores a waystone's location as the raw block position of its block entity. For a waystone
- * placed on an assembled Sable sub-level (e.g. an aircraft) that position is the hidden plot-yard
- * coordinate (~20.48M blocks out), not the contraption's rendered location.
+ * Lets Waystones teleport onto Sable sub-levels (e.g. an aircraft).
  *
- * <p>Sable already projects {@link net.minecraft.server.level.ServerPlayer#teleportTo} out of the
- * sub-level, but Waystones' same-dimension warp path teleports via
- * {@code connection.teleport(...)} directly, bypassing that projection. The player is dropped into the
- * plot-yard, which desyncs the sub-level stream ("Received a sub-level movement packet for a
- * non-existent sub-level") and freezes the server thread.
+ * <p>A waystone placed on an assembled sub-level is stored at the hidden plot-yard coordinate. Two
+ * things need to happen for a warp onto it to work:
  *
- * <p>Project the teleport target out of the sub-level before the entity is moved. This affects only
- * the entity placement (the warp-plate / modifier block-entity lookups still use the original plot
- * position via {@code destination.location()}).
+ * <ul>
+ *   <li>The teleport target is projected out of the sub-level to the contraption's real (or, while
+ *       unloaded, last-known) world position. Waystones' same-dimension warp uses
+ *       {@code connection.teleport(...)} directly, bypassing Sable's {@code ServerPlayer#teleportTo}
+ *       projection, so without this the player is dropped into the plot-yard and the server freezes.
+ *   <li>If the contraption is currently unloaded, the player is frozen to the sub-level after the
+ *       teleport. Teleporting to the last-known position re-activates the held sub-level (its holding
+ *       chunk is keyed by that world position); the freeze then places the player precisely on the
+ *       deck once it is live - the same mechanism Sable uses for bed respawns.
+ * </ul>
+ *
  * {@link dev.ryanhcode.sable.api.SubLevelHelper#projectOutOfSubLevel} is a no-op for positions that
- * are not inside a sub-level, so this is safe for ordinary warps and idempotent with the
- * cross-dimension {@code teleportTo} path that Sable already handles.
+ * are not inside a sub-level, so ordinary warps are unaffected.
  */
 @Mixin(targets = "net.blay09.mods.waystones.core.WaystoneTeleportManager", remap = false)
 public class WaystoneTeleportManagerMixin {
 
-    @ModifyVariable(
-            method = "teleportEntity(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/core/Direction;)Lnet/minecraft/world/entity/Entity;",
-            at = @At("HEAD"),
-            argsOnly = true,
-            index = 2
-    )
-    private static Vec3 sable$projectTeleportTargetOutOfSubLevel(final Vec3 targetPos3d, @Local(argsOnly = true) final ServerLevel targetWorld) {
+    private static final String TELEPORT_ENTITY = "teleportEntity(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/core/Direction;)Lnet/minecraft/world/entity/Entity;";
+
+    @ModifyVariable(method = TELEPORT_ENTITY, at = @At("HEAD"), argsOnly = true, index = 2)
+    private static Vec3 sable$projectTeleportTarget(final Vec3 targetPos3d, @Local(argsOnly = true) final ServerLevel targetWorld, @Share("sableHeldFreeze") final LocalRef<Pair<UUID, Vector3d>> freezeRef) {
+        // If the waystone is on a currently-unloaded sub-level, remember which sub-level (and the
+        // local anchor) so the player can be frozen to it after the teleport.
+        final UUID heldUuid = sable$heldSubLevelUuid(targetWorld, targetPos3d);
+        if (heldUuid != null) {
+            freezeRef.set(Pair.of(heldUuid, new Vector3d(targetPos3d.x, targetPos3d.y, targetPos3d.z)));
+        }
+
         return Sable.HELPER.projectOutOfSubLevel(targetWorld, targetPos3d);
+    }
+
+    @Inject(method = TELEPORT_ENTITY, at = @At("RETURN"))
+    private static void sable$freezeOntoSubLevel(final Entity entity, final ServerLevel targetWorld, final Vec3 targetPos3d, final Direction direction, final CallbackInfoReturnable<Entity> cir, @Share("sableHeldFreeze") final LocalRef<Pair<UUID, Vector3d>> freezeRef) {
+        final Pair<UUID, Vector3d> freeze = freezeRef.get();
+        if (freeze == null) {
+            return;
+        }
+
+        if (cir.getReturnValue() instanceof final ServerPlayer player) {
+            ((PlayerFreezeExtension) player).sable$freezeTo(freeze.first(), freeze.second());
+            player.connection.send(new ClientboundCustomPayloadPacket(new ClientboundFreezePlayerPacket(freeze.first(), freeze.second())));
+        }
+    }
+
+    /**
+     * @return the UUID of the held (unloaded) sub-level whose plot contains the given target, or
+     * {@code null} if the target is in open world or on an already-loaded sub-level (in which case the
+     * ordinary teleport plus entity-sticking is enough).
+     */
+    private static @Nullable UUID sable$heldSubLevelUuid(final ServerLevel level, final Vec3 pos) {
+        if (Sable.HELPER.getContaining(level, pos.x, pos.z) != null) {
+            return null;
+        }
+        final SubLevelContainer container = SubLevelContainer.getContainer(level);
+        if (container == null) {
+            return null;
+        }
+        final int chunkX = Mth.floor(pos.x) >> SectionPos.SECTION_BITS;
+        final int chunkZ = Mth.floor(pos.z) >> SectionPos.SECTION_BITS;
+        return container.getLastKnownUuid(chunkX, chunkZ);
     }
 }

--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/storage/SubLevelOccupancySavedData.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/storage/SubLevelOccupancySavedData.java
@@ -78,8 +78,7 @@ public class SubLevelOccupancySavedData extends SavedData {
 
         compoundTag.putLongArray("sub_level_occupancy", longArray);
 
-        // persist each reserved plot's last-known pose so distance/cost queries stay accurate for
-        // sub-levels that are still unloaded after a restart
+        // persist each reserved plot's last-known pose & uuid for sub-levels still unloaded after a restart
         final ListTag poses = new ListTag();
         for (int index = occupancy.nextSetBit(0); index >= 0; index = occupancy.nextSetBit(index + 1)) {
             final Pose3d pose = container.getPersistablePose(index);

--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/storage/SubLevelOccupancySavedData.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/storage/SubLevelOccupancySavedData.java
@@ -1,8 +1,12 @@
 package dev.ryanhcode.sable.sublevel.storage;
 
 import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
+import dev.ryanhcode.sable.companion.math.Pose3d;
+import dev.ryanhcode.sable.util.SableNBTUtils;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.datafix.DataFixTypes;
 import net.minecraft.world.level.saveddata.SavedData;
@@ -45,6 +49,14 @@ public class SubLevelOccupancySavedData extends SavedData {
             final BitSet occupancy = container.getOccupancy();
             occupancy.clear();
             occupancy.or(occupancyData);
+
+            // restore the last-known pose of each reserved (possibly unloaded) plot
+            final ListTag poses = tag.getList("last_known_poses", Tag.TAG_COMPOUND);
+            for (int i = 0; i < poses.size(); i++) {
+                final CompoundTag entry = poses.getCompound(i);
+                final Pose3d pose = SableNBTUtils.readPose3d(entry.getCompound("pose"));
+                container.setLastKnownPose(entry.getInt("index"), pose);
+            }
         }
 
         return data;
@@ -60,6 +72,21 @@ public class SubLevelOccupancySavedData extends SavedData {
         final long[] longArray = occupancy.toLongArray();
 
         compoundTag.putLongArray("sub_level_occupancy", longArray);
+
+        // persist each reserved plot's last-known pose so distance/cost queries stay accurate for
+        // sub-levels that are still unloaded after a restart
+        final ListTag poses = new ListTag();
+        for (int index = occupancy.nextSetBit(0); index >= 0; index = occupancy.nextSetBit(index + 1)) {
+            final Pose3d pose = container.getPersistablePose(index);
+            if (pose == null) {
+                continue;
+            }
+            final CompoundTag entry = new CompoundTag();
+            entry.putInt("index", index);
+            entry.put("pose", SableNBTUtils.writePose3d(pose));
+            poses.add(entry);
+        }
+        compoundTag.put("last_known_poses", poses);
 
         return compoundTag;
     }

--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/storage/SubLevelOccupancySavedData.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/storage/SubLevelOccupancySavedData.java
@@ -12,6 +12,7 @@ import net.minecraft.util.datafix.DataFixTypes;
 import net.minecraft.world.level.saveddata.SavedData;
 
 import java.util.BitSet;
+import java.util.UUID;
 
 /**
  * Stores the map for which plots are occupied
@@ -54,8 +55,12 @@ public class SubLevelOccupancySavedData extends SavedData {
             final ListTag poses = tag.getList("last_known_poses", Tag.TAG_COMPOUND);
             for (int i = 0; i < poses.size(); i++) {
                 final CompoundTag entry = poses.getCompound(i);
+                final int index = entry.getInt("index");
                 final Pose3d pose = SableNBTUtils.readPose3d(entry.getCompound("pose"));
-                container.setLastKnownPose(entry.getInt("index"), pose);
+                container.setLastKnownPose(index, pose);
+                if (entry.hasUUID("uuid")) {
+                    container.setLastKnownUuid(index, entry.getUUID("uuid"));
+                }
             }
         }
 
@@ -84,6 +89,10 @@ public class SubLevelOccupancySavedData extends SavedData {
             final CompoundTag entry = new CompoundTag();
             entry.putInt("index", index);
             entry.put("pose", SableNBTUtils.writePose3d(pose));
+            final UUID uuid = container.getLastKnownUuid(index);
+            if (uuid != null) {
+                entry.putUUID("uuid", uuid);
+            }
             poses.add(entry);
         }
         compoundTag.put("last_known_poses", poses);

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -110,6 +110,7 @@
     "compatibility.vista.LODMixin",
     "compatibility.vista.ViewFinderAccessMixin",
     "compatibility.vista.ViewFinderControllerMixin",
+    "compatibility.waystones.WaystoneTeleportManagerMixin",
     "death_message.CombatTrackerMixin",
     "death_message.EntityMixin",
     "enchanting_table.EnchantingTableBlockEntityMixin",

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -17,6 +17,7 @@
     "clip_overwrite.ClientLevelMixin",
     "clip_overwrite.GameRendererMixin",
     "compatibility.iris.ExtendedShaderMixin",
+    "compatibility.waystones.WaystoneButtonMixin",
     "config.GameRendererAccessor",
     "debug_render.DebugRendererMixin",
     "debug_render.DebugScreenOverlayMixin",

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -110,6 +110,7 @@
     "compatibility.vista.LODMixin",
     "compatibility.vista.ViewFinderAccessMixin",
     "compatibility.vista.ViewFinderControllerMixin",
+    "compatibility.waystones.WaystoneImplMixin",
     "compatibility.waystones.WaystoneTeleportManagerMixin",
     "death_message.CombatTrackerMixin",
     "death_message.EntityMixin",


### PR DESCRIPTION
### Summary

Makes [Waystones](https://modrinth.com/mod/waystones) work with sub-levels. Without this, a waystone placed on an assembled sub-level (e.g. an aircraft) is broken in three ways: warping to it **freezes the server**, warping to an **unloaded** contraption is refused outright, and its **distance/XP cost** read as a meaningless ~20,000 km. After this PR you can place a waystone on a contraption and warp to it normally — loaded or unloaded.

All Waystones-specific code is a self-contained `compatibility/waystones` mixin package, auto-gated by `SableMixinPlugin` (no hard dependency — Sable loads fine without Waystones). Tested against Waystones `21.1.34` on NeoForge 1.21.1.

### The problem

A waystone stores its block position, which for a block on a sub-level is the hidden plot-yard coordinate (`DEFAULT_ORIGIN` → ~20.48M blocks out). Waystones treats that as a normal world position:

- **Freeze:** the same-dimension warp path calls `ServerGamePacketListenerImpl#teleport` directly, bypassing Sable's existing `ServerPlayer#teleportTo` projection, so the player is flung into the plot-yard.
- **Refusal:** `WaystoneImpl#isValidInLevel` reads `getBlockState(pos)`, which is air while the contraption is unloaded → "currently being moved or has gone missing".
- **Bad distance:** while unloaded there's no live pose to project against, so the plot-yard coordinate leaks into distance/cost on both server and client.

### Changes

**Core (used by the compat mixins, but generally applicable):**
- `SubLevelContainer` now remembers a **last-known pose and UUID per plot**, set on allocate and kept while a sub-level is merely unloaded (cleared only on `REMOVED`). Persisted alongside plot occupancy in `SubLevelOccupancySavedData`. This lets a held sub-level's position/identity be resolved without loading it.
- `ActiveSableCompanion#projectOutOfSubLevel` falls back to that last-known pose when no sub-level is loaded at the position (previously it returned the raw plot-yard coordinate). This flows through `distanceSquaredWithSubLevels` → the `Entity#distanceToSqr` overwrite, so server-side distance/cost (`is_within_distance`, the `distance` cost variable, `/waystones list`) become correct for unloaded sub-levels.

**Compat mixins (`compatibility/waystones`):**
- `WaystoneTeleportManagerMixin` — projects the teleport target out of the sub-level; and if the target is on an unloaded contraption, freezes the player to `(subLevelId, localAnchor)` after the teleport.
- `WaystoneImplMixin` — treats a waystone on a reserved-but-unloaded plot as a valid teleport target.
- `WaystoneButtonMixin` (client) — omits the distance for a waystone whose sub-level isn't loaded here, reusing the same "no distance shown" path Waystones already uses for cross-dimension waystones.

### How the unloaded warp works

It reuses the exact mechanism Sable already uses for **bed respawns onto sub-levels**: held sub-levels are stored in holding chunks keyed by their global world position, so teleporting the player to the contraption's last-known position re-activates it; the freeze then holds the player until the sub-level is live and places them precisely on the deck.

### Testing

Manually, on a real modpack (Create: Aeronautics-style + Waystones, NeoForge 1.21.1):
- Warp to a waystone on a loaded aircraft → lands on the deck (previously froze the server).
- Warp to a waystone on an **unloaded** aircraft → world loads at its last position, player lands on the deck (previously "missing").
- XP cost → correct for both loaded and unloaded.
- GUI distance → real distance when loaded, blank when unloaded, unchanged for ordinary far-away waystones.

### Notes for reviewers

- **The `projectOutOfSubLevel` change looks wide but is provably safe for loaded sub-levels:** `subLevels[index]` is written only in `allocateSubLevel` (set) and `removeSubLevel` (null), so `getContaining` never returns null during a loaded sub-level's lifetime — the new fallback branch is unreachable while loaded, and behaves identically across the load/unload boundary (`lastKnownPose == logicalPose` at unload). If you'd prefer it explicit, I'm happy to split it into a dedicated `projectOutOfSubLevelOrLastKnown` so the shared primitive is untouched.
- **`lastKnownUuids`** is new (respawn uses tracking points for identity instead). It's needed because waystones aren't proactively registered like beds, so we need a position→identity lookup for an unloaded sub-level.

### Known limitations

- The warp trusts that a reserved plot still holds the waystone (no disk-read validation of the block while unloaded).
- Re-activation must land within the freeze window (~160 ticks); a very slow chunk load would drop the player at the contraption's last position.
- Client GUI distance is omitted (not computed) while the sub-level is unloaded; an accurate value would require streaming last-known poses to clients.