### PR TITLE
Fix typo in wiki/Home.md link

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,5 +1,5 @@
 ## Depending on Sable
-[![Sable 1.21.1](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fmaven.ryanhcode.dev%2Freleases%2Fdev%2Fryanhcode%2Fsable%2Fsable-common-1.21.1%2Fmaven-metadata.xml&label=Sable%201.21.1)]([-1.21.1/](https://maven.ryanhcode.dev/releases/dev/ryanhcode/sable/sable-common-1.21.1/))
+[![Sable 1.21.1](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fmaven.ryanhcode.dev%2Freleases%2Fdev%2Fryanhcode%2Fsable%2Fsable-common-1.21.1%2Fmaven-metadata.xml&label=Sable%201.21.1)](https://maven.ryanhcode.dev/releases/dev/ryanhcode/sable/sable-common-1.21.1/)
 
 Copy the following segments into your `build.gradle` file depending on the platform:
 


### PR DESCRIPTION
the link was pointing to another markdown link within the link. so i made the link point to the correct link which was inside the link's link