### PR TITLE
Add server config for physics steps

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/SableConfig.java
+++ b/common/src/main/java/dev/ryanhcode/sable/SableConfig.java
@@ -18,8 +18,8 @@ public final class SableConfig {
     public static final ModConfigSpec.IntValue SUB_LEVEL_PUNCH_COOLDOWN_TICKS;
     public static final ModConfigSpec.BooleanValue DISABLE_UDP_PIPELINE;
     public static final ModConfigSpec.BooleanValue ATTEMPT_UDP_NETWORKING;
-    public static final ModConfigSpec.BooleanValue VERBOSE_SERIALIZATION_LOGGING;
     public static final ModConfigSpec.BooleanValue SUB_LEVEL_SAVING_LOG_MESSAGE;
+    public static final ModConfigSpec.BooleanValue VERBOSE_SERIALIZATION_LOGGING;
 
     static {
         final ModConfigSpec.Builder builder = new ModConfigSpec.Builder();

--- a/common/src/main/java/dev/ryanhcode/sable/SableServerConfig.java
+++ b/common/src/main/java/dev/ryanhcode/sable/SableServerConfig.java
@@ -1,0 +1,20 @@
+package dev.ryanhcode.sable;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class SableServerConfig {
+
+    public static final ModConfigSpec SPEC;
+
+    public static final ModConfigSpec.IntValue SUB_LEVEL_SUBSTEPS_PER_TICK;
+
+    static {
+        final ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+
+        SUB_LEVEL_SUBSTEPS_PER_TICK = builder
+                .comment("How many times the physics simulation is stepped in every second. Higher values will be significantly more performance intensive, but will have higher accuracy.")
+                .defineInRange("sub_level_substeps_per_tick", 2, 1, 10);
+
+        SPEC = builder.build();
+    }
+}

--- a/common/src/main/java/dev/ryanhcode/sable/config/SubLevelSettingsScreen.java
+++ b/common/src/main/java/dev/ryanhcode/sable/config/SubLevelSettingsScreen.java
@@ -1,5 +1,6 @@
 package dev.ryanhcode.sable.config;
 
+import dev.ryanhcode.sable.SableServerConfig;
 import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
 import dev.ryanhcode.sable.physics.config.PhysicsConfigData;
 import dev.ryanhcode.sable.sublevel.system.SubLevelPhysicsSystem;
@@ -10,6 +11,7 @@ import net.minecraft.client.gui.screens.options.OptionsSubScreen;
 import net.minecraft.client.server.IntegratedServer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import net.neoforged.neoforge.common.ModConfigSpec;
 
 public class SubLevelSettingsScreen extends OptionsSubScreen {
     public static final Component TITLE = Component.translatable("options.sable_menu");
@@ -22,18 +24,20 @@ public class SubLevelSettingsScreen extends OptionsSubScreen {
     protected void addOptions() {
         final IntegratedServer singleplayerServer = this.minecraft.getSingleplayerServer();
 
-
+        final ModConfigSpec.Range<?> range = SableServerConfig.SUB_LEVEL_SUBSTEPS_PER_TICK.getSpec().getRange();
         this.list.addBig(new OptionInstance<>(
                 "options.physics_steps",
                 OptionInstance.cachedConstantTooltip(Component.translatable("options.physics_steps.tooltip")),
                 (component, substeps) -> Options.genericValueLabel(component, Component.translatable("options.physics_steps_template", substeps * 20)),
-                new OptionInstance.IntRange(1, 10, false),
+                new OptionInstance.IntRange((Integer) range.getMin(), (Integer) range.getMax(), false),
                 SubLevelContainer.getContainer(singleplayerServer.overworld()).physicsSystem().getConfig().substepsPerTick,
                 steps -> {
+                    SableServerConfig.SUB_LEVEL_SUBSTEPS_PER_TICK.set(steps);
+                    SableServerConfig.SPEC.save();
                     for (final ServerLevel level : singleplayerServer.getAllLevels()) {
                         final SubLevelPhysicsSystem physicsSystem = SubLevelContainer.getContainer(level).physicsSystem();
                         final PhysicsConfigData config = physicsSystem.getConfig();
-                        config.substepsPerTick = steps;
+                        config.updateFromConfig();
                         physicsSystem.getPipeline().updateConfigFrom(config);
                     }
                 }

--- a/common/src/main/java/dev/ryanhcode/sable/physics/config/PhysicsConfigData.java
+++ b/common/src/main/java/dev/ryanhcode/sable/physics/config/PhysicsConfigData.java
@@ -1,5 +1,8 @@
 package dev.ryanhcode.sable.physics.config;
 
+import dev.ryanhcode.sable.SableConfig;
+import dev.ryanhcode.sable.SableServerConfig;
+
 public class PhysicsConfigData {
     /**
      * The number of solver iterations run by the constraints solver for calculating forces.
@@ -28,4 +31,8 @@ public class PhysicsConfigData {
      * Physics ticks done per game tick in the physics pipeline.
      */
     public int substepsPerTick = 2;
+
+    public void updateFromConfig() {
+        this.substepsPerTick = SableServerConfig.SUB_LEVEL_SUBSTEPS_PER_TICK.getAsInt();
+    }
 }

--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/system/SubLevelPhysicsSystem.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/system/SubLevelPhysicsSystem.java
@@ -168,6 +168,7 @@ public class SubLevelPhysicsSystem implements SubLevelObserver {
         final Vector3d gravity = new Vector3d(DimensionPhysicsData.getGravity(this.level));
         final double universalDrag = DimensionPhysicsData.getUniversalDrag(this.level);
 
+        this.config.updateFromConfig();
         this.pipeline.init(gravity, universalDrag);
         this.pipeline.updateConfigFrom(this.config);
     }

--- a/fabric/src/main/java/dev/ryanhcode/sable/fabric/SableFabric.java
+++ b/fabric/src/main/java/dev/ryanhcode/sable/fabric/SableFabric.java
@@ -3,6 +3,7 @@ package dev.ryanhcode.sable.fabric;
 import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.SableCommonEvents;
 import dev.ryanhcode.sable.SableConfig;
+import dev.ryanhcode.sable.SableServerConfig;
 import dev.ryanhcode.sable.command.SableCommand;
 import dev.ryanhcode.sable.command.argument.SubLevelSelectorModifiers;
 import dev.ryanhcode.sable.index.SableAttributes;
@@ -43,5 +44,6 @@ public final class SableFabric implements ModInitializer {
         ServerLifecycleEvents.SYNC_DATA_PACK_CONTENTS.register((player, joined) -> SableCommonEvents.syncDataPacket(packet -> player.connection.send(packet)));
 
         NeoForgeConfigRegistry.INSTANCE.register(Sable.MOD_ID, ModConfig.Type.COMMON, SableConfig.SPEC);
+        NeoForgeConfigRegistry.INSTANCE.register(Sable.MOD_ID, ModConfig.Type.SERVER, SableServerConfig.SPEC);
     }
 }

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/SableNeoForge.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/SableNeoForge.java
@@ -3,6 +3,7 @@ package dev.ryanhcode.sable.neoforge;
 import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.SableCommonEvents;
 import dev.ryanhcode.sable.SableConfig;
+import dev.ryanhcode.sable.SableServerConfig;
 import dev.ryanhcode.sable.command.SableCommand;
 import dev.ryanhcode.sable.command.argument.SubLevelSelectorModifiers;
 import dev.ryanhcode.sable.index.SableAttributes;
@@ -42,6 +43,7 @@ public final class SableNeoForge {
         attributes.register(modBus);
 
         modContainer.registerConfig(ModConfig.Type.COMMON, SableConfig.SPEC);
+        modContainer.registerConfig(ModConfig.Type.SERVER, SableServerConfig.SPEC);
 
         CrashReportCallables.registerHeader(Sable::getCrashHeader);
     }


### PR DESCRIPTION
This adds a server config that physics steps are written to. The runtime physics config is kept, but updated from the config value instead of not being saved anywhere. I used a server config so the data is saved per world instead of per instance.

Closes #1234 