### PR TITLE
disallow drills to be used as paddles

### DIFF
--- a/common/src/main/resources/data/sable/tags/item/paddles.json
+++ b/common/src/main/resources/data/sable/tags/item/paddles.json
@@ -2,5 +2,8 @@
   "replace": false,
   "values": [
     "#minecraft:shovels"
+  ],
+  "remove": [
+    "#c:tools/drill"
   ]
 }


### PR DESCRIPTION
Improves compat with mods such as Gregtech that add drills that can be used as shovels, by disallowing them to be used as paddles.