### PR TITLE
Re-orient entity collision box per sub-level and substep

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/entity_collision/SubLevelEntityCollision.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/entity_collision/SubLevelEntityCollision.java
@@ -207,6 +207,16 @@ public class SubLevelEntityCollision {
                 lastPose.lerp(logicalPose, (double) (i - 1) / substeps, lastSubLevelPose);
                 lastPose.lerp(logicalPose, (double) (i) / substeps, subLevelPose);
 
+                // Re-orient the entity's collision box to THIS sub-level's pose at THIS substep.
+                // The computation before the loop reads subLevelPose before it has been set for the
+                // current iteration, so the box was oriented to the previous substep's pose — or to
+                // a different sub-level entirely — making entities catch on walls and doorframes of
+                // rotated sub-levels.
+                if (customEntityOrientation == null) {
+                    sink.entityBoxOrientation.identity().rotateY(getHitBoxYaw(subLevelPose));
+                    entityBoundsOBB.setOrientation(sink.entityBoxOrientation);
+                }
+
                 rotatedContextBounds.set(fullContextBounds);
                 if (customEntityOrientation != null) {
                     entityBoundsOBB.vertices(sink.a);


### PR DESCRIPTION
## The bug

Entities catch on walls and doorframes of sub-levels that are oriented at an angle — walking through a 1-wide doorway on a yawed contraption snags on the frame even though the entity's oriented collision box should clear it.

## Root cause

In `SubLevelEntityCollision.collide()`, the entity's OBB yaw is computed at the top of the substep loop:

```java
sink.entityBoxOrientation.identity();
final double yaw = getHitBoxYaw(subLevelPose);
sink.entityBoxOrientation.rotateY(yaw);
```

but `subLevelPose` is only assigned *inside* the per-sub-level loop (`lastPose.lerp(logicalPose, i / substeps, subLevelPose)`), i.e. **after** this read. The box is therefore oriented to the previous substep's pose — or, when several sub-levels are loaded, to a **different sub-level entirely** (whatever the reused sink held last). On rotated sub-levels the collision box is intermittently mis-yawed, which reads in-game as snagging on geometry the box should pass.

## The fix

Recompute the box orientation inside the per-sub-level loop, immediately after the substep pose lerp, so every SAT test uses the orientation of the sub-level actually being collided at the current substep. The `customEntityOrientation` path is deliberately left on the original code path to avoid disturbing its up-direction and eye-height handling.

## Testing

- 1-wide doorway on a walkway attached to a swivel bearing, parked at an angle: walking through from both sides no longer catches on the frame (previously snagged repeatedly).
- Same test with a second contraption assembled nearby (the worst case for the stale read): still clean.
- Regression: flat/unrotated contraptions, spinning platforms (16–100+ RPM), and tilted decks behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)