### PR TITLE
Fixed Create mechanical rollers not filling correctly by bypassing block breaking distance check

### DIFF
--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/behaviour_compatibility/block_breaking_behaviour/BlockBreakingMovementBehaviourMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/behaviour_compatibility/block_breaking_behaviour/BlockBreakingMovementBehaviourMixin.java
@@ -3,6 +3,7 @@ package dev.ryanhcode.sable.neoforge.mixin.compatibility.create.behaviour_compat
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.content.contraptions.actors.roller.RollerMovementBehaviour;
 import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 import com.simibubi.create.content.kinetics.base.BlockBreakingMovementBehaviour;
 import dev.ryanhcode.sable.ActiveSableCompanion;
@@ -76,7 +77,7 @@ public abstract class BlockBreakingMovementBehaviourMixin implements MovementBeh
                     targetCenter = targetSubLevel.logicalPose().transformPosition(targetCenter);
                 }
 
-                if (sublevelLocalCenter.distanceToSqr(targetCenter) > 2 * 2) {
+                if (sublevelLocalCenter.distanceToSqr(targetCenter) > 2 * 2 &&  !((Object) this instanceof RollerMovementBehaviour)) {
                     data.remove("Progress");
                     data.remove("TicksUntilNextProgress");
                     data.remove("BreakingPos");


### PR DESCRIPTION
Create mechanical rollers' "Sloped Fill" and "Straight Fill" modes interact with blocks much further away than other actors, and so should be excluded from Sable's distance check on whether to cancel the interaction in testBreakingPosDist in BlockBreakingMovementBehaviourMixin.java. 

Error: Create Mechanical Rollers on Create trains do not fill below the first layer when Create and Sable are installed (Latest versions for Neoforge 1.21.1). 

Fix: Add check for whether the MovementBehaviour is a RollerMovementBehaviour in the distance check in testBreakingPosDist.