### PR TITLE
Fix Create crushing wheel entity transforms in sub-levels

### DIFF
--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/crushing_wheel_entity_processing/CrushingWheelControllerBlockEntityMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/crushing_wheel_entity_processing/CrushingWheelControllerBlockEntityMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -22,10 +23,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(CrushingWheelControllerBlockEntity.class)
 public abstract class CrushingWheelControllerBlockEntityMixin extends SmartBlockEntity {
 
+    @Unique
+    private static final double SABLE$MAX_CRUSHING_POSITION_DISTANCE_SQR = 64.0;
+
     @Shadow
     public Entity processingEntity;
     @Unique
     private SubLevel sable$parentSublevel = null;
+    @Unique
+    private boolean sable$warnedInvalidPosition;
+    @Unique
+    private boolean sable$warnedInvalidVelocity;
 
     public CrushingWheelControllerBlockEntityMixin(final BlockEntityType<?> typeIn, final BlockPos pos, final BlockState state) {
         super(typeIn, pos, state);
@@ -76,5 +84,74 @@ public abstract class CrushingWheelControllerBlockEntityMixin extends SmartBlock
         }
 
         return z;
+    }
+
+    @WrapOperation(
+            method = "tick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/Entity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V"
+            ),
+            require = 1,
+            allow = 1
+    )
+    public void sable$transformCrushingVelocity(final Entity instance, final Vec3 localVelocity, final Operation<Void> original) {
+        if (this.sable$parentSublevel == null) {
+            original.call(instance, localVelocity);
+            return;
+        }
+
+        final Vec3 worldVelocity = this.sable$parentSublevel.logicalPose().transformNormal(localVelocity);
+        if (!sable$isFinite(worldVelocity)) {
+            if (!this.sable$warnedInvalidVelocity) {
+                this.sable$warnedInvalidVelocity = true;
+                Sable.LOGGER.error(
+                        "Invalid crushing-wheel velocity transform at {} for entity {}: local={}, transformed={}",
+                        this.getBlockPos(), instance.getUUID(), localVelocity, worldVelocity
+                );
+            }
+            original.call(instance, Vec3.ZERO);
+            return;
+        }
+
+        original.call(instance, worldVelocity);
+    }
+
+    @WrapOperation(
+            method = "tick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/Entity;setPos(DDD)V"
+            ),
+            require = 2,
+            allow = 2
+    )
+    public void sable$transformCrushingPosition(final Entity instance, final double localX, final double localY, final double localZ, final Operation<Void> original) {
+        if (this.sable$parentSublevel == null) {
+            original.call(instance, localX, localY, localZ);
+            return;
+        }
+
+        final Vec3 localPosition = new Vec3(localX, localY, localZ);
+        final Vec3 worldPosition = this.sable$parentSublevel.logicalPose().transformPosition(localPosition);
+        final boolean invalid = !sable$isFinite(worldPosition)
+                || worldPosition.distanceToSqr(instance.position()) > SABLE$MAX_CRUSHING_POSITION_DISTANCE_SQR;
+        if (invalid) {
+            if (!this.sable$warnedInvalidPosition) {
+                this.sable$warnedInvalidPosition = true;
+                Sable.LOGGER.error(
+                        "Blocked unsafe crushing-wheel position at {} for entity {}: local={}, transformed={}, current={}",
+                        this.getBlockPos(), instance.getUUID(), localPosition, worldPosition, instance.position()
+                );
+            }
+            return;
+        }
+
+        original.call(instance, worldPosition.x, worldPosition.y, worldPosition.z);
+    }
+
+    @Unique
+    private static boolean sable$isFinite(final Vec3 vector) {
+        return Double.isFinite(vector.x) && Double.isFinite(vector.y) && Double.isFinite(vector.z);
     }
 }


### PR DESCRIPTION
## Problem

Create's crushing wheel controller reads entity positions through Sable's transformed accessors, but writes local/storage coordinates directly through `Entity#setPos`. It also applies local delta movement without rotating it into world space.

For players, the invalid position can cause the next collision query to scan an enormous area and stall the server. Items can also be deflected instead of being processed.

This addresses the coordinate mismatch described in #593 at the crushing-wheel integration point instead of clamping the resulting movement globally, as attempted in #1042.

## Changes

- Transform the crushing-wheel `Entity#setDeltaMovement` call with `logicalPose().transformNormal`.
- Transform both crushing-wheel `Entity#setPos` calls with `logicalPose().transformPosition`.
- Apply the transformations only when the controller is inside a Sable sub-level.
- Add finite-value and eight-block position safety guards.
- Require the expected invocation counts so incompatible Create updates fail visibly.

## Testing

Runtime-tested with Create 6.0.10 and Sable 2.0.3:

- Single items and full stacks
- Belt and chute input
- Player death and respawn
- Level and tilted ships
- No TPS freeze, watchdog failure, or movement/guard warnings
- `/tick query`: approximately 9 ms before testing and 20 ms afterward

Known visual limitation: crushing particles can render offset from the wheel center.

`git diff --check` passes. 

Fixes #593