### PR TITLE
Fix sub-level shader block IDs and single-block model data on NeoForge

### DIFF
--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/iris/ModelBlockRendererMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/iris/ModelBlockRendererMixin.java
@@ -1,0 +1,65 @@
+package dev.ryanhcode.sable.neoforge.mixin.compatibility.iris;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.irisshaders.iris.shaderpack.materialmap.WorldRenderingSettings;
+import net.irisshaders.iris.vertices.BlockSensitiveBufferBuilder;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.ModelBlockRenderer;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ModelBlockRenderer.class)
+public class ModelBlockRendererMixin {
+
+    @Unique
+    private void sable$beginBlock(final BlockState state, final BlockPos pos, final VertexConsumer consumer) {
+        if (!(consumer instanceof BlockSensitiveBufferBuilder buffer)) {
+            return;
+        }
+
+        final Object2IntMap<BlockState> blockStateIds = WorldRenderingSettings.INSTANCE.getBlockStateIds();
+        if (blockStateIds == null) {
+            return;
+        }
+
+        buffer.beginBlock(blockStateIds.getOrDefault(state, -1), (byte) 0, (byte) state.getLightEmission(), pos.getX() & 15, pos.getY() & 15, pos.getZ() & 15);
+    }
+
+    @Unique
+    private void sable$endBlock(final VertexConsumer consumer) {
+        if (consumer instanceof BlockSensitiveBufferBuilder buffer) {
+            buffer.endBlock();
+        }
+    }
+
+    @Inject(method = "tesselateWithAO(Lnet/minecraft/world/level/BlockAndTintGetter;Lnet/minecraft/client/resources/model/BakedModel;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;ZLnet/minecraft/util/RandomSource;JILnet/neoforged/neoforge/client/model/data/ModelData;Lnet/minecraft/client/renderer/RenderType;)V", at = @At("HEAD"))
+    private void sable$beginBlockAO(final BlockAndTintGetter level, final BakedModel model, final BlockState state, final BlockPos pos, final PoseStack poseStack, final VertexConsumer consumer, final boolean checkSides, final RandomSource random, final long seed, final int packedOverlay, final ModelData modelData, final RenderType renderType, final CallbackInfo ci) {
+        this.sable$beginBlock(state, pos, consumer);
+    }
+
+    @Inject(method = "tesselateWithAO(Lnet/minecraft/world/level/BlockAndTintGetter;Lnet/minecraft/client/resources/model/BakedModel;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;ZLnet/minecraft/util/RandomSource;JILnet/neoforged/neoforge/client/model/data/ModelData;Lnet/minecraft/client/renderer/RenderType;)V", at = @At("RETURN"))
+    private void sable$endBlockAO(final BlockAndTintGetter level, final BakedModel model, final BlockState state, final BlockPos pos, final PoseStack poseStack, final VertexConsumer consumer, final boolean checkSides, final RandomSource random, final long seed, final int packedOverlay, final ModelData modelData, final RenderType renderType, final CallbackInfo ci) {
+        this.sable$endBlock(consumer);
+    }
+
+    @Inject(method = "tesselateWithoutAO(Lnet/minecraft/world/level/BlockAndTintGetter;Lnet/minecraft/client/resources/model/BakedModel;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;ZLnet/minecraft/util/RandomSource;JILnet/neoforged/neoforge/client/model/data/ModelData;Lnet/minecraft/client/renderer/RenderType;)V", at = @At("HEAD"))
+    private void sable$beginBlockFlat(final BlockAndTintGetter level, final BakedModel model, final BlockState state, final BlockPos pos, final PoseStack poseStack, final VertexConsumer consumer, final boolean checkSides, final RandomSource random, final long seed, final int packedOverlay, final ModelData modelData, final RenderType renderType, final CallbackInfo ci) {
+        this.sable$beginBlock(state, pos, consumer);
+    }
+
+    @Inject(method = "tesselateWithoutAO(Lnet/minecraft/world/level/BlockAndTintGetter;Lnet/minecraft/client/resources/model/BakedModel;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;ZLnet/minecraft/util/RandomSource;JILnet/neoforged/neoforge/client/model/data/ModelData;Lnet/minecraft/client/renderer/RenderType;)V", at = @At("RETURN"))
+    private void sable$endBlockFlat(final BlockAndTintGetter level, final BakedModel model, final BlockState state, final BlockPos pos, final PoseStack poseStack, final VertexConsumer consumer, final boolean checkSides, final RandomSource random, final long seed, final int packedOverlay, final ModelData modelData, final RenderType renderType, final CallbackInfo ci) {
+        this.sable$endBlock(consumer);
+    }
+}

--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/platform/SableSubLevelRenderPlatformImpl.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/platform/SableSubLevelRenderPlatformImpl.java
@@ -28,7 +28,7 @@ public class SableSubLevelRenderPlatformImpl implements SableSubLevelRenderPlatf
 
     @Override
     public List<RenderType> getRenderLayers(final SingleBlockSubLevelWrapper blockAndTintGetter, final BakedModel bakedModel, final BlockState blockState, final BlockPos pos, final RandomSource randomSource) {
-        return bakedModel.getRenderTypes(blockState, randomSource, blockAndTintGetter.getModelData(pos)).asList();
+        return bakedModel.getRenderTypes(blockState, randomSource, blockAndTintGetter.getLevel().getModelData(pos)).asList();
     }
 
     @Override

--- a/neoforge/src/main/resources/sable-neoforge.mixins.json
+++ b/neoforge/src/main/resources/sable-neoforge.mixins.json
@@ -60,6 +60,7 @@
     "compatibility.flywheel.RenderDispatcherImplMixin",
     "compatibility.flywheel.ShaderSourcesMixin",
     "compatibility.flywheel.VisualManagerImplMixin",
+    "compatibility.iris.ModelBlockRendererMixin",
     "compatibility.pmweather.RadarRendererMixin",
     "compatibility.sodiumextras.EmbyToolsMixin",
     "dynamic_directional_shading.SectionCompilerMixin",


### PR DESCRIPTION
Fix two sub-level rendering issues on NeoForge, both caused by the vanilla render path
being fed something different from what actually meshes the geometry.

## 1. Shader packs get no block ID for anything on a sub-level

`ReachAroundSubLevelRenderDispatcher` meshes sub-levels with a vanilla `SectionRenderDispatcher`
rather than Sodium. Iris instruments the two paths separately, and only the Sodium one has a
caller:

- **Sodium** - `MixinChunkMeshBuildTask` calls `VertexEncoderInterface#beginBlock` per block.
- **Vanilla** - `MixinBufferBuilder` implements `BlockSensitiveBufferBuilder` and *does* write the
  ID into `IrisVertexFormats.ENTITY_ELEMENT`, but nothing in Iris ever calls `beginBlock` on it.
  In `iris-neoforge-1.8.14-beta.1+mc1.21.1.jar` the only classes referencing that interface are the
  interface itself and the mixin implementing it.

So `currentBlock` keeps its initial `-1` for every block meshed for a sub-level, and shaders see
`mc_Entity.x == -1`. Under Complementary that skips the entirety of `terrainIPBR.glsl`, which is
wrapped in a single `if (mat >= 10000)`: gold stops being metallic, glowstone stops being
emissive, and every block loses its integrated-PBR material properties the moment it is assembled
into a physics object. Disassembling restores them.

This adds `compatibility/iris/ModelBlockRendererMixin`, which brackets
`ModelBlockRenderer#tesselateWithAO` and `#tesselateWithoutAO` with `beginBlock`/`endBlock` when the
consumer is a `BlockSensitiveBufferBuilder`. It sits under `mixin.compatibility.iris`, so
`AbstractSableMixinPlugin` already gates it on Iris being loaded.

Both sub-level data paths converge on those two methods and only those two.
`VanillaChunkedSubLevelRenderData` reaches them through `SectionCompiler` and `renderBatched`,
while `VanillaSingleSubLevelRenderData`, used when a physics object is exactly one block, calls
`tesselateWithoutAO` directly from `SableSubLevelRenderPlatformImpl`, bypassing `renderBatched`
entirely. Bracketing the dispatcher instead covers the first but silently misses the second.

Note the vanilla path writes `currentBlock` **raw** as a short, unlike the Sodium encoder's
`(id + 1) << 1 | renderType` packing - so the value from `getBlockStateIds()` is passed through
unchanged.

## 2. Models whose render layers depend on model data are invisible on single-block sub-levels

`SableSubLevelRenderPlatformImpl` asks two different sources for the same block's `ModelData`:

```java
// geometry - correct
tesselateBlock(...)  -> blockAndTintGetter.getLevel().getModelData(pos)

// render layers - always ModelData.EMPTY
getRenderLayers(...) -> blockAndTintGetter.getModelData(pos)
```

`SingleBlockSubLevelWrapper` is in the `common` source set and so cannot override NeoForge's
`BlockAndTintGetter#getModelData`, leaving it on the default of `ModelData.EMPTY`. Any model whose
`getRenderTypes` depends on its model data therefore reports **no layers**, and
`VanillaSingleSubLevelRenderData#renderSingleBlock` returns before it ever reaches the tesselate
call that would have worked.

The symptom is oddly specific and was how I found it: a physics object made of exactly one such
block is invisible, and adding any second block makes both appear, because that switches to
`VanillaChunkedSubLevelRenderData`, which uses the level's manager throughout.

Fixed by having `getRenderLayers` query the level, matching `tesselateBlock` directly above it.

## Testing

Sodium + Iris + Complementary Reimagined with integrated PBR (no resource pack):

1. Place a gold block and a glowstone block; note the metallic / emissive shading.
2. Assemble them into a Create Aeronautics physics object - before this change they shade as
   untyped blocks; after it they keep their material properties.
3. For (2), assemble a single block whose render layers come from its model data (any dynamic
   block-entity model) - invisible before, drawn after.
