### PR TITLE
Let ParCool see sub-levels

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/parcool/WorldUtilMixin.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixin/compatibility/parcool/WorldUtilMixin.java
@@ -1,0 +1,31 @@
+package dev.ryanhcode.sable.mixin.compatibility.parcool;
+
+import dev.ryanhcode.sable.mixinhelpers.SubLevelNoCollisionHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(targets = "com.alrex.parcool.utilities.WorldUtil", remap = false)
+public class WorldUtilMixin {
+
+    @Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;noCollision(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;)Z"), require = 0)
+    private static boolean sable$noCollisionForEntity(final Level level, final Entity entity, final AABB aabb) {
+        if (!level.noCollision(entity, aabb)) {
+            return false;
+        }
+
+        return SubLevelNoCollisionHelper.noCollisionWithSubLevels(level, aabb);
+    }
+
+    @Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;noCollision(Lnet/minecraft/world/phys/AABB;)Z"), require = 0)
+    private static boolean sable$noCollision(final Level level, final AABB aabb) {
+        if (!level.noCollision(aabb)) {
+            return false;
+        }
+
+        return SubLevelNoCollisionHelper.noCollisionWithSubLevels(level, aabb);
+    }
+}

--- a/common/src/main/java/dev/ryanhcode/sable/mixinhelpers/SubLevelNoCollisionHelper.java
+++ b/common/src/main/java/dev/ryanhcode/sable/mixinhelpers/SubLevelNoCollisionHelper.java
@@ -1,0 +1,94 @@
+package dev.ryanhcode.sable.mixinhelpers;
+
+import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.api.math.LevelReusedVectors;
+import dev.ryanhcode.sable.api.math.OrientedBoundingBox3d;
+import dev.ryanhcode.sable.companion.math.BoundingBox3d;
+import dev.ryanhcode.sable.companion.math.BoundingBox3dc;
+import dev.ryanhcode.sable.companion.math.Pose3dc;
+import dev.ryanhcode.sable.mixinterface.entity.entity_sublevel_collision.LevelExtension;
+import dev.ryanhcode.sable.mixinterface.voxel_shape_iteration.FastVoxelShapeIterable;
+import dev.ryanhcode.sable.sublevel.SubLevel;
+import dev.ryanhcode.sable.sublevel.entity_collision.SubLevelEntityCollision;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.joml.Matrix4d;
+import org.joml.Vector3d;
+
+import java.util.Iterator;
+
+public class SubLevelNoCollisionHelper {
+
+    public static boolean noCollisionWithSubLevels(final Level level, final AABB aabb) {
+        final BoundingBox3d considerationBounds = new BoundingBox3d(aabb);
+        considerationBounds.expand(1.05, considerationBounds);
+
+        final Iterable<SubLevel> intersecting = Sable.HELPER.getAllIntersecting(level, considerationBounds);
+
+        final LevelReusedVectors sink = ((LevelExtension) level).sable$getJOMLSink();
+
+        sink.entityBoxOrientation.identity();
+        final OrientedBoundingBox3d queryOBB = new OrientedBoundingBox3d(
+                (aabb.minX + aabb.maxX) / 2.0,
+                (aabb.minY + aabb.maxY) / 2.0,
+                (aabb.minZ + aabb.maxZ) / 2.0,
+                aabb.getXsize(),
+                aabb.getYsize(),
+                aabb.getZsize(),
+                sink.entityBoxOrientation,
+                sink);
+
+        final OrientedBoundingBox3d cubeOBB = new OrientedBoundingBox3d(sink);
+        final BoundingBox3d localBounds = new BoundingBox3d();
+        final Matrix4d bakedPose = new Matrix4d();
+
+        final Vector3d center = new Vector3d();
+        final Vector3d satResult = new Vector3d();
+
+        for (final SubLevel subLevel : intersecting) {
+            final Pose3dc pose = subLevel.lastPose();
+            localBounds.set(aabb);
+            localBounds.transformInverse(pose, bakedPose, localBounds);
+
+            final Iterable<BlockPos> blocks = BlockPos.betweenClosed(
+                    BlockPos.containing(localBounds.minX, localBounds.minY, localBounds.minZ),
+                    BlockPos.containing(localBounds.maxX, localBounds.maxY, localBounds.maxZ));
+
+            cubeOBB.getOrientation().set(pose.orientation());
+
+            sink.entityBoxOrientation.identity().rotateY(SubLevelEntityCollision.getHitBoxYaw(pose));
+            queryOBB.setOrientation(sink.entityBoxOrientation);
+
+            for (final BlockPos block : blocks) {
+                final BlockState state = level.getBlockState(block);
+
+                if (state.isAir()) {
+                    continue;
+                }
+
+                final VoxelShape voxelShape = state.getCollisionShape(level, block);
+
+                final Iterator<BoundingBox3dc> iterator = ((FastVoxelShapeIterable) voxelShape).sable$allBoxes();
+                while (iterator.hasNext()) {
+                    final BoundingBox3dc box = iterator.next();
+                    box.center(center);
+                    cubeOBB.getPosition().set(block.getX() + center.x,
+                            block.getY() + center.y,
+                            block.getZ() + center.z);
+                    pose.transformPosition(cubeOBB.getPosition());
+                    box.size(cubeOBB.getDimensions());
+
+                    OrientedBoundingBox3d.sat(queryOBB, cubeOBB, satResult);
+                    if (satResult.lengthSquared() > 0 && satResult.x() != Double.MAX_VALUE && satResult.y() != Double.MAX_VALUE && satResult.z() != Double.MAX_VALUE) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/common/src/main/resources/sable.mixins.json
+++ b/common/src/main/resources/sable.mixins.json
@@ -114,6 +114,7 @@
     "compatibility.jade.BlockAccessorImplMixin",
     "compatibility.jade.RayTracingMixin",
     "compatibility.jadeaddons.CreatePluginMixin",
+    "compatibility.parcool.WorldUtilMixin",
     "compatibility.shouldersurfing.EntityHelperMixin",
     "compatibility.shouldersurfing.PerspectiveMixin",
     "compatibility.shouldersurfing.ShoulderSurfingCameraMixin",


### PR DESCRIPTION
None of its parkour moves function on a physics object today.
Wall-running, wall-jumping, vaulting and ledge grabs all fail.

## Cause

Every wall, ledge and step ParCool looks for is found the same way: build a box around the player,
expand it toward a candidate surface, and ask whether anything is in the way.

```java
// ParCool, WorldUtil#getWall - and getRunnableWall, getVaultableStep, getGrabbableWall alike
if (boxes.stream().noneMatch(box -> entity.level().noCollision(box.expandTowards(range, 0.0, 0.0)))) {
    wallX++;
}
```

There is no raycast anywhere in `WorldUtil` - 31 probes across the class, every one of them a
`Level#noCollision` call.

Sable makes collision work on a sub-level by redirecting the specific vanilla call sites that
matter - `Entity#collide` while moving, `Player#canFallAtLeast`, and so on. `Level#noCollision`
itself is untouched, and `entity_sublevel_collision.LevelMixin` only carries the JOML sink. So a
mod that reaches for `noCollision` directly gets vanilla's answer: the world where the structure
appears to be is empty air, the structure is invisible to it, and ParCool concludes there is no
wall to run along and no ledge to grab.

Strictly this is not a ParCool bug - any mod probing collision that way is blind to sub-levels in
the same manner.

## Fix

`compatibility/parcool/WorldUtilMixin` redirects both `noCollision` overloads across the class
through a sub-level check. It sits under `mixin.compatibility.parcool`, so
`AbstractSableMixinPlugin` already gates it on ParCool being loaded, and it needs no compile
dependency on ParCool: every type in the redirected signatures is vanilla, so the mixin targets by
name.

Redirecting the whole class rather than a chosen method is deliberate. The actions share one blind
spot, and a per-action list would silently miss whatever ParCool adds next. Vanilla is still asked
first, so this can only ever turn a "clear" answer into an "occupied" one - it cannot invent a wall
that neither the level nor a sub-level has.

## Why a new helper rather than `CanFallAtleastHelper`

The geometry is deliberately the same - `Sable.HELPER.getAllIntersecting`, `transformInverse` into
the sub-level's frame, then `OrientedBoundingBox3d.sat` per collision box - but the existing helper
answers a different question:

```java
localBounds.minY -= 1.0; // fences
```

It grows the query box downward and drops its lower bound by a block so a fence post still counts
as ground underfoot. That is right for "is there anything to land on" and wrong for "is there a
wall here", where it would report a wall a metre above any floor. Hence `SubLevelNoCollisionHelper`
- the same traversal with honest box bounds.

## Testing

ParCool + Create Aeronautics, parkour actions enabled:

1. Build a wall a few blocks high on a physics object and assemble it.
2. Run at the wall, wall-run and wall-jump do nothing before this change, and behave as they do on
   ordinary terrain after it.
3. Jump at the top edge of that wall - likewise the ledge grab.
4. Vault a one-block step on the same structure.

One area I would welcome a second opinion on: the query box is transformed into the sub-level's
frame and tested with SAT, so a **rotating or steeply banked** structure is the interesting case
rather than a level one. If the probe boxes want tightening there, `SubLevelNoCollisionHelper`
keeps them at full size, where `CanFallAtleastHelper` shrinks its equivalent by `0.1` on X and Z.
