### PR TITLE
Remove potentially problematic memory optimization in BlockSubLevelLiftProvider

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/api/block/BlockSubLevelLiftProvider.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/block/BlockSubLevelLiftProvider.java
@@ -23,26 +23,6 @@ public interface BlockSubLevelLiftProvider {
 
     Direction[] DIRECTIONS = Direction.values();
 
-    // memory optimization
-    Vector3d LIFT_FORCE = new Vector3d();
-    Vector3d LIFT_POS = new Vector3d();
-    Vector3d LIFT_NORMAL = new Vector3d();
-
-    Vector3d LIFT_VELO = new Vector3d();
-    Vector3d DRAG = new Vector3d();
-    Vector3d TEMP = new Vector3d();
-
-    /**
-     * Resets the vectors to their identity.
-     */
-    static void resetVectors() {
-        LIFT_VELO.set(0, 0, 0);
-        LIFT_POS.set(0, 0, 0);
-        LIFT_FORCE.set(0, 0, 0);
-        LIFT_NORMAL.set(0, 0, 0);
-        DRAG.set(0, 0, 0);
-    }
-
     static List<LiftProviderGroup> groupLiftProviders(final Collection<LiftProviderContext> liftProviders) {
         final List<LiftProviderGroup> groups = new ObjectArrayList<>();
         final Set<BlockPos> positions = new ObjectOpenHashSet<>(liftProviders.size());
@@ -133,52 +113,56 @@ public interface BlockSubLevelLiftProvider {
                                              final Vector3dc linearVelocity, final Vector3dc angularVelocity,
                                              final Vector3d linearImpulse, final Vector3d angularImpulse,
                                              @Nullable final LiftProviderGroup group) {
-        resetVectors();
-        LIFT_NORMAL.set(ctx.dir.x(), ctx.dir.y(), ctx.dir.z());
-        LIFT_POS.set(ctx.pos.getX() + 0.5, ctx.pos.getY() + 0.5, ctx.pos.getZ() + 0.5);
+
+        final Vector3d liftNormal = new Vector3d(ctx.dir.x(), ctx.dir.y(), ctx.dir.z());
+        final Vector3d liftPos = new Vector3d(ctx.pos.getX() + 0.5, ctx.pos.getY() + 0.5, ctx.pos.getZ() + 0.5);
+        final Vector3d liftForce = new Vector3d();
+        final Vector3d transformedPos = new Vector3d();
+        final Vector3d drag = new Vector3d();
 
         if (localPose != null) {
-            localPose.transformNormal(LIFT_NORMAL);
-            localPose.transformPosition(LIFT_POS);
+            localPose.transformNormal(liftNormal);
+            localPose.transformPosition(liftPos);
         }
 
         final Pose3d pose = subLevel.logicalPose();
-        final double pressure = DimensionPhysicsData.getAirPressure(subLevel.getLevel(), pose.transformPosition(LIFT_POS, TEMP));
+        final double pressure = DimensionPhysicsData.getAirPressure(subLevel.getLevel(), pose.transformPosition(liftPos, transformedPos));
 
         // transform VELO to be the local velocity at the center of the block
         // TEMP = transformed POS
         // VELO = linVel + angVel cross TEMP
         // VELO = inv transformed VELO
-        pose.transformPosition(LIFT_POS, TEMP).sub(pose.position());
-        LIFT_VELO.set(linearVelocity).add(angularVelocity.cross(TEMP, TEMP));
-        pose.transformNormalInverse(LIFT_VELO);
+        pose.transformPosition(liftPos, transformedPos).sub(pose.position());
+        final Vector3d liftVelo = new Vector3d(linearVelocity).add(angularVelocity.cross(transformedPos, transformedPos));
+        pose.transformNormalInverse(liftVelo);
 
-        LIFT_FORCE.zero();
+        liftForce.zero(); // optional, zero default
 
         if (this.sable$getParallelDragScalar() > 0) {
             // DRAG = NORMAL * (NORMAL dot VELO)
             // FORCE = DRAG * scalars
-            final double dragStrength = LIFT_NORMAL.dot(LIFT_VELO) * this.sable$getParallelDragScalar() * pressure * timeStep;
-            final Vector3d parallelDrag = LIFT_NORMAL.mul(dragStrength, DRAG);
-            LIFT_FORCE.add(parallelDrag);
+            final double dragStrength = liftNormal.dot(liftVelo) * this.sable$getParallelDragScalar() * pressure * timeStep;
+            final Vector3d parallelDrag = liftNormal.mul(dragStrength, drag);
+            liftForce.add(parallelDrag);
 
             if (group != null) {
                 group.totalDrag.sub(parallelDrag);
-                group.dragCenter.fma(Math.abs(dragStrength), LIFT_POS);
+                group.dragCenter.fma(Math.abs(dragStrength), liftPos);
                 group.totalDragStrength += Math.abs(dragStrength);
             }
         }
 
         if (this.sable$getDirectionlessDragScalar() > 0) {
+            final Vector3d scaledVelo = new Vector3d();
             // TEMP = VELO * scalars
             // FORCE += TEMP
             final double dragStrength = this.sable$getDirectionlessDragScalar() * pressure * timeStep;
-            final Vector3d directionlessDrag = LIFT_VELO.mul(dragStrength, TEMP);
-            LIFT_FORCE.add(directionlessDrag);
+            final Vector3d directionlessDrag = liftVelo.mul(dragStrength, scaledVelo);
+            liftForce.add(directionlessDrag);
 
             if (group != null) {
                 group.totalDrag.sub(directionlessDrag);
-                group.dragCenter.fma(directionlessDrag.length(), LIFT_POS);
+                group.dragCenter.fma(directionlessDrag.length(), liftPos);
                 group.totalDragStrength += directionlessDrag.length();
             }
         }
@@ -187,22 +171,25 @@ public interface BlockSubLevelLiftProvider {
             // TEMP = VELO - DRAG
             // TEMP = NORMAL * |TEMP| * scalars
             // FORCE += TEMP
-            final double liftStrength = LIFT_VELO.sub(DRAG, TEMP).length() * this.sable$getLiftScalar() * pressure * timeStep;
-            final Vector3d lift = LIFT_NORMAL.mul(liftStrength, TEMP);
-            LIFT_FORCE.add(lift);
+
+            final Vector3d temp = new Vector3d();
+
+            final double liftStrength = liftVelo.sub(drag, temp).length() * this.sable$getLiftScalar() * pressure * timeStep;
+            final Vector3d lift = liftNormal.mul(liftStrength, temp);
+            liftForce.add(lift);
 
             if (group != null) {
                 group.totalLift.sub(lift);
-                group.liftCenter.fma(Math.abs(liftStrength), LIFT_POS);
+                group.liftCenter.fma(Math.abs(liftStrength), liftPos);
                 group.totalLiftStrength += liftStrength;
             }
         }
 
         // why is this all negative of what it should be?
-        linearImpulse.sub(LIFT_FORCE);
-        LIFT_POS.sub(subLevel.getMassTracker().getCenterOfMass(), TEMP);
-        angularImpulse.sub(TEMP.cross(LIFT_FORCE));
-        resetVectors();
+        linearImpulse.sub(liftForce);
+        final Vector3d liftOffset = new Vector3d();
+        liftPos.sub(subLevel.getMassTracker().getCenterOfMass(), liftOffset);
+        angularImpulse.sub(liftOffset.cross(liftForce));
     }
 
     record LiftProviderContext(BlockPos pos, BlockState state, Vec3 dir) {


### PR DESCRIPTION
Avoid using "globals to avoid allocation", this way JIT can do proper escape analysis, do proper optimizations (and make the function thread-safe too)

More details on escape analysis:
https://docs.oracle.com/javase/8/docs/technotes/guides/vm/performance-enhancements-7.html#escapeAnalysis

There are many reasons why I would not create globals to avoid allocation:
- Escape analysis can stack promote all the internal vectors (that cannot leave the function scope), stack promoted things can be promoted to registers
- even if allocated, allocations will be in current cache, it is less likely for the code to cache-miss.
- updating object fields would slow-down the function more (since GC barriers are a thing), this way that doesn't happen.
- since I can avoid TEMP, the math is a bit more readable.
- accidentally made the function thread-safe.

I was thinking on what might be worse with this, but I couldn't find many reasons. Some allocations will occur before JIT compiles the function, but that probably doesn't matter (since compilation will happen pretty fast)
Also because this patch removes a few fields, it might break some mods, so merging this might be a bit risky.

And since the function isn't a performance bottleneck anyway, I would say this PR is pretty low priority.
