### PR TITLE
Fix ticket map lookup key type mismatch and logging placeholder format

### DIFF
--- a/common/src/main/java/dev/ryanhcode/sable/api/sublevel/SubLevelTicketLoadingSystem.java
+++ b/common/src/main/java/dev/ryanhcode/sable/api/sublevel/SubLevelTicketLoadingSystem.java
@@ -34,7 +34,7 @@ public class SubLevelTicketLoadingSystem implements SubLevelObserver {
         if (reason == SubLevelRemovalReason.UNLOADED) {
             this.container.activeTickets.remove(serverSubLevel);
 
-            final SubLevelTicketInfo info = this.container.allTickets.get(serverSubLevel);
+            final SubLevelTicketInfo info = this.container.allTickets.get(serverSubLevel.getUniqueId());
 
             if (info != null) {
                 info.setPointer(serverSubLevel.getLastSerializationPointer());

--- a/common/src/main/java/dev/ryanhcode/sable/sublevel/storage/serialization/SubLevelSerializer.java
+++ b/common/src/main/java/dev/ryanhcode/sable/sublevel/storage/serialization/SubLevelSerializer.java
@@ -156,7 +156,7 @@ public class SubLevelSerializer {
         try {
             subLevel = (ServerSubLevel) plotContainer.allocateSubLevel(halfLoadedSubLevel.uuid(), plotX, plotZ, pose);
         } catch (final IllegalArgumentException e) {
-            Sable.LOGGER.error("Failed to load sub-level, skipping", halfLoadedSubLevel, e);
+            Sable.LOGGER.error("Failed to load sub-level {}, skipping", halfLoadedSubLevel, e);
             return null;
         }
 


### PR DESCRIPTION
Fixed an issue in `SubLevelTicketLoadingSystem` where passing a `ServerSubLevel` instance instead of its `UUID` to `allTickets.get()` resulted in `null` lookups and prevented ticket pointers from persisting on unload. Also added a missing `{}` placeholder in `SubLevelSerializer` error logging.