### PR TITLE
Removed LittleTiles as incompatibility

### DIFF
--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -68,7 +68,3 @@ reason = "${mod_name} supports Sodium ${sodium_version} and above"
 [[dependencies.sable]]
 modId = "scalablelux"
 type = "incompatible"
-
-[[dependencies.sable]]
-modId = "littletiles"
-type = "incompatible"


### PR DESCRIPTION
Hey there,

I am the author of LittleTiles and worked on supporting sable the past weeks. It is finally finished and out. Would be great if the incompatibility marker is removed. Version 1.6.0pre223 and newer support sable.

In Regards
CreativeMD