### PR TITLE
fix: skip massless blocks in sable$buildProperties

### DIFF
--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/contraptions/AbstractContraptionEntityMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/contraptions/AbstractContraptionEntityMixin.java
@@ -153,7 +153,7 @@ public abstract class AbstractContraptionEntityMixin extends Entity implements K
             final StructureTemplate.StructureBlockInfo info = entry.getValue();
             final BlockState state = info.state();
 
-            if (state.isAir()) continue;
+            if (state.isAir() || PhysicsBlockPropertyHelper.getMass(this.sable$blockGetter(), blockPos, state) == 0) continue;
 
             if (this.sable$localBounds == null) {
                 this.sable$localBounds = new BoundingBox3i(blockPos.getX(), blockPos.getY(), blockPos.getZ(), blockPos.getX(), blockPos.getY(), blockPos.getZ());


### PR DESCRIPTION
This pr adds a check for massless blocks in buildProperties, skipping them alongside air blocks. This way, buildProperties for contraptions that consist of only massless / non solid blocks will return early, skipping the unchecked getCenterOfMass().negate() call that causes the crash.

I'm not sure if sable intends for massless / non solid blocks to potentially be a BlockSubLevelLiftProvider or floating material. If so, buildProperties will no longer set up these properties for massless blocks and some other fix will need to be found.

fix #457