### PR TITLE
Fixing a crash we got on our server

### DIFF
--- a/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/contraptions/AbstractContraptionEntityMixin.java
+++ b/neoforge/src/main/java/dev/ryanhcode/sable/neoforge/mixin/compatibility/create/contraptions/AbstractContraptionEntityMixin.java
@@ -179,8 +179,9 @@ public abstract class AbstractContraptionEntityMixin extends Entity implements K
             this.sable$massTracker = null;
             return;
         }
-
-        final Vector3d temp = this.sable$massTracker.getCenterOfMass().negate(new Vector3d()).add(0.5, 0.5, 0.5);
+        var centerOfMass = this.sable$massTracker.getCenterOfMass();
+        if (centerOfMass == null) return;
+        final Vector3d temp = centerOfMass.negate(new Vector3d()).add(0.5, 0.5, 0.5);
         for (final FloatingBlockCluster cluster : this.sable$floatingClusterContainer.clusters) {
             cluster.getBlockData().translateOrigin(temp);
         }


### PR DESCRIPTION
Hi, we had an issue recently where someone did some weird combination of things and broke a nearby contraption to the point that the entire server crashes upon loading the chunk. I narrowed down the issue to a missing null check when attempting to find the center of mass of the contraption. From what I saw, there IS a null check, but it happens slightly later in the initialization Mixin which leads me to believe that this was unintentional. All I did was expand out a line so I could verify the center of mass exists before continuing. 

I won't be too butthurt if you decide to fix this some other way; I just thought it would be worth a PR so you could look at it yourself. I do not fully understand the circumstances required in order to cause this bug, and I was unable to recreate it myself, outside of the broken chunk on our server. I suspect it has to do with a race condition of some kind where the contraption has not figured out its sable data before initializing. 

The player told me he was using a steering wheel while standing on a contraption when it broke. My best guess is that rapid assembly/disassembly of a contraption due to the steering wheel has something to do with it. From what I was told, there was not a sublevel anywhere nearby, so it's likely that the contraption Mixin is the sole culprit.