### PR TITLE
Update build instructions following recent change

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Join sable zone for development discussion: https://discord.gg/pnkzu2dtVA
 # Building Rust Natives
 
 1. Install Docker from https://www.docker.com/get-started/ or from your relevant package manager
-2. Run `gradlew common:buildImages` (only has to be done once)
-3. Run `gradlew common:buildRustNatives`
+2. Run `gradlew sable_rapier:buildImages` (only has to be done once)
+3. Run `gradlew sable_rapier:buildRustNatives`
 
 ### Thanks
 


### PR DESCRIPTION
A recent commit (effec5f3da06556b1ca16a288499d144027940be) separated `sable_rapier` into its own module. The build instructions on the README hadn't been updated to reflect that change. This tiny patch does that. 